### PR TITLE
universal DB connection (merge *after* pull #35)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn backend.project:project

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -1,0 +1,9 @@
+# Comma-separated list of hosts allowed by Django
+ALLOWED_HOSTS=localhost,127.0.0.1
+# 50-ish char secret key for Django. In quotes.
+SECRET_KEY=""
+# Django Debug. True in dev. False in prod except for firefighting.
+DEBUG=True
+
+# Local PostgreSQL config
+DATABASE_URL=postgres://Username:Password@localhost:5432/db-name

--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -9,6 +9,8 @@ python-decouple = "*"
 djangorestframework = "*"
 django-rest-auth = "*"
 django-allauth = "*"
+dj-database-url = "*"
+"psycopg2-binary" = "*"
 
 [dev-packages]
 

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3e8226888fc9eacfbd42d9dd2883d8853b44568f50a20d6188b8637f07632518"
+            "sha256": "4b53994a65bf547b6f55f8469442a96f21bebed19da59d5c004146d3816b7191"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -35,6 +35,14 @@
                 "sha256:24d7f2f94f7f3cb6061acb215685e5125fbcdc40a857eff9de22518820b0a4f4",
                 "sha256:702a91ade2968a82beb0db1e0766a6a273f33d4616a6ce8cde475d8e09853b20"
             ],
+            "version": "==0.5.0"
+        },
+        "dj-database-url": {
+            "hashes": [
+                "sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163",
+                "sha256:851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9"
+            ],
+            "index": "pypi",
             "version": "==0.5.0"
         },
         "django": {
@@ -80,6 +88,49 @@
                 "sha256:d883b36b21a6ad813953803edfa563b1b579d79ca758fe950d1bc9e8b326025b"
             ],
             "version": "==2.1.0"
+        },
+        "psycopg2-binary": {
+            "hashes": [
+                "sha256:036bcb198a7cc4ce0fe43344f8c2c9a8155aefa411633f426c8c6ed58a6c0426",
+                "sha256:1d770fcc02cdf628aebac7404d56b28a7e9ebec8cfc0e63260bd54d6edfa16d4",
+                "sha256:1fdc6f369dcf229de6c873522d54336af598b9470ccd5300e2f58ee506f5ca13",
+                "sha256:21f9ddc0ff6e07f7d7b6b484eb9da2c03bc9931dd13e36796b111d631f7135a3",
+                "sha256:247873cda726f7956f745a3e03158b00de79c4abea8776dc2f611d5ba368d72d",
+                "sha256:3aa31c42f29f1da6f4fd41433ad15052d5ff045f2214002e027a321f79d64e2c",
+                "sha256:475f694f87dbc619010b26de7d0fc575a4accf503f2200885cc21f526bffe2ad",
+                "sha256:4b5e332a24bf6e2fda1f51ca2a57ae1083352293a08eeea1fa1112dc7dd542d1",
+                "sha256:570d521660574aca40be7b4d532dfb6f156aad7b16b5ed62d1534f64f1ef72d8",
+                "sha256:59072de7def0690dd13112d2bdb453e20570a97297070f876fbbb7cbc1c26b05",
+                "sha256:5f0b658989e918ef187f8a08db0420528126f2c7da182a7b9f8bf7f85144d4e4",
+                "sha256:649199c84a966917d86cdc2046e03d536763576c0b2a756059ae0b3a9656bc20",
+                "sha256:6645fc9b4705ae8fbf1ef7674f416f89ae1559deec810f6dd15197dfa52893da",
+                "sha256:6872dd54d4e398d781efe8fe2e2d7eafe4450d61b5c4898aced7610109a6df75",
+                "sha256:6ce34fbc251fc0d691c8d131250ba6f42fd2b28ef28558d528ba8c558cb28804",
+                "sha256:73920d167a0a4d1006f5f3b9a3efce6f0e5e883a99599d38206d43f27697df00",
+                "sha256:8a671732b87ae423e34b51139628123bc0306c2cb85c226e71b28d3d57d7e42a",
+                "sha256:8d517e8fda2efebca27c2018e14c90ed7dc3f04d7098b3da2912e62a1a5585fe",
+                "sha256:9475a008eb7279e20d400c76471843c321b46acacc7ee3de0b47233a1e3fa2cf",
+                "sha256:96947b8cd7b3148fb0e6549fcb31258a736595d6f2a599f8cd450e9a80a14781",
+                "sha256:abf229f24daa93f67ac53e2e17c8798a71a01711eb9fcdd029abba8637164338",
+                "sha256:b1ab012f276df584beb74f81acb63905762c25803ece647016613c3d6ad4e432",
+                "sha256:b22b33f6f0071fe57cb4e9158f353c88d41e739a3ec0d76f7b704539e7076427",
+                "sha256:b3b2d53274858e50ad2ffdd6d97ce1d014e1e530f82ec8b307edd5d4c921badf",
+                "sha256:bab26a729befc7b9fab9ded1bba9c51b785188b79f8a2796ba03e7e734269e2e",
+                "sha256:daa1a593629aa49f506eddc9d23dc7f89b35693b90e1fbcd4480182d1203ea90",
+                "sha256:dd111280ce40e89fd17b19c1269fd1b74a30fce9d44a550840e86edb33924eb8",
+                "sha256:e0b86084f1e2e78c451994410de756deba206884d6bed68d5a3d7f39ff5fea1d",
+                "sha256:eb86520753560a7e89639500e2a254bb6f683342af598088cb72c73edcad21e6",
+                "sha256:ff18c5c40a38d41811c23e2480615425c97ea81fd7e9118b8b899c512d97c737"
+            ],
+            "index": "pypi",
+            "version": "==2.7.6.1"
+        },
+        "python-decouple": {
+            "hashes": [
+                "sha256:1317df14b43efee4337a4aa02914bf004f010cd56d6c4bd894e6474ec8c4fe2d"
+            ],
+            "index": "pypi",
+            "version": "==3.1"
         },
         "python3-openid": {
             "hashes": [

--- a/backend/env.template
+++ b/backend/env.template
@@ -1,3 +1,5 @@
+# Copy the contents of this file into a '.env' file in the same directory, then update the variables in that file.
+
 # Comma-separated list of hosts allowed by Django
 ALLOWED_HOSTS=localhost,127.0.0.1
 # 50-ish char secret key for Django. In quotes.
@@ -6,4 +8,5 @@ SECRET_KEY=""
 DEBUG=True
 
 # Local PostgreSQL config
+# Unless you've made a different database or user, they are both 'postgres' by default with the container.
 DATABASE_URL=postgres://Username:Password@localhost:5432/db-name

--- a/backend/project/settings.py
+++ b/backend/project/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
 import os
+import dj_database_url
 
 from decouple import config, Csv
 
@@ -85,15 +86,11 @@ WSGI_APPLICATION = 'project.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
+# Set up to use dj_database_url
+SSL_MODE = '?sslmode=prefer'
+PG_URL = config('DATABASE_URL') + SSL_MODE
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': config('NAME'),
-        'USER': config('USER'),
-        'PASSWORD': config('PASSWORD'),
-        'HOST': config('HOST'),
-        'PORT': config('PORT', cast=int),
-    }
+    'default' : dj_database_url.config(default=PG_URL)
 }
 
 # REST boilerplate to set up persmissions

--- a/backend/project/urls.py
+++ b/backend/project/urls.py
@@ -18,17 +18,17 @@ from django.urls import path, include
 
 from django.conf.urls import url, include
 from django.contrib.auth.models import User
-from rest_framework import routers, serializers, viewsets
+# from rest_framework import routers, serializers, viewsets
 
 # Routers provide an easy way of automatically determining the URL conf.
-router = routers.DefaultRouter()
-router.register(r'users', UserViewSet)
+# router = routers.DefaultRouter()
+# router.register(r'users', UserViewSet)
 
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
-    url(r'^', include(router.urls)),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+    # url(r'^', include(router.urls)),
+    # url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     path('admin/', admin.site.urls),
     path('api/', include('api.urls'))
 ]


### PR DESCRIPTION
# Description

Added dj_database_url and psycopg2-binary libraries
Configured the default database connection settings to use dj_database_url, with a bit of sprinkles added to the DATABASE_URL to manage SSL differences between dev and prod, before feeding it into the config.
Added in changes from pull #35 to try and mitigate merge conflicts
*Also* adds a Procfile to the repo root to launch the backend when pushed to Heroku. Heroku specific, untested.

Fixes # https://trello.com/c/0rOFzsry/59-wire-up-django-to-work-with-both-local-and-prod-databases

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Tested as thoroughly as possible against my dev DB, including trying to pass sslmode via the URL, since dj_database_url doesn't support the option explicitly, but appears to support them implicitly when parsing the passed URL. Things *appear* to work as expected. Would like a FSW dev or two to pull this down and try it locally.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
