### PR TITLE
Implements sign out capability

### DIFF
--- a/ios/Anywhere Reader/Anywhere Reader/AppDelegate.swift
+++ b/ios/Anywhere Reader/Anywhere Reader/AppDelegate.swift
@@ -20,13 +20,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         AppearanceHelper.setUpTheme()
         
-        if let _ = GIDSignIn.sharedInstance()?.hasAuthInKeychain() {
-            let sb = UIStoryboard(name: "Main", bundle: nil)
-            let vc = sb.instantiateInitialViewController()
-            self.window?.rootViewController = vc
-            self.window?.makeKeyAndVisible()
+        if let isSignedIn = GIDSignIn.sharedInstance()?.hasAuthInKeychain() {
+            if isSignedIn {
+                let sb = UIStoryboard(name: "Main", bundle: nil)
+                let vc = sb.instantiateInitialViewController()
+                self.window?.rootViewController = vc
+                self.window?.makeKeyAndVisible()
+            }
         }
-        
         return true
     }
     

--- a/ios/Anywhere Reader/Anywhere Reader/Resources/Storyboard/Settings.storyboard
+++ b/ios/Anywhere Reader/Anywhere Reader/Resources/Storyboard/Settings.storyboard
@@ -224,6 +224,12 @@
                         <viewLayoutGuide key="safeArea" id="hYC-nm-OsM"/>
                     </view>
                     <navigationItem key="navigationItem" id="5pe-OV-EVe">
+                        <barButtonItem key="leftBarButtonItem" title="Log Out" id="XoS-Ek-uJm">
+                            <color key="tintColor" red="1" green="0.14913141730000001" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <connections>
+                                <action selector="logOut:" destination="Enx-cX-gv1" id="6wO-lP-05d"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" systemItem="stop" id="MSe-rK-J5c">
                             <connections>
                                 <action selector="dismissSettingsVC:" destination="Enx-cX-gv1" id="72E-gw-3zS"/>

--- a/ios/Anywhere Reader/Anywhere Reader/View Controller/Segmented/SegmentedSettingsViewController.swift
+++ b/ios/Anywhere Reader/Anywhere Reader/View Controller/Segmented/SegmentedSettingsViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import GoogleSignIn
 
 class SegmentedSettingsViewController: UIViewController {
     
@@ -44,8 +45,28 @@ class SegmentedSettingsViewController: UIViewController {
     @IBAction func segmentedControlTapped(_ sender: Any) {
         updateViews()
     }
+    
     @IBAction func dismissSettingsVC(_ sender: Any) {
         dismiss(animated: true, completion: nil)
+    }
+    
+    @IBAction func logOut(_ sender: Any) {
+        
+        let alertController = UIAlertController(title: "Are you sure you want to sign out?", message: nil, preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+        let signOutAction = UIAlertAction(title: "Sign Out", style: .destructive) { _ in
+            GIDSignIn.sharedInstance().signOut()
+            let isSignedIn = GIDSignIn.sharedInstance()?.hasAuthInKeychain()
+            if isSignedIn == nil || isSignedIn == false {
+                    let sb = UIStoryboard(name: "Authentication", bundle: nil)
+                    let vc = sb.instantiateInitialViewController()!
+                    self.present(vc, animated: false)
+            }
+        }
+        alertController.addAction(cancelAction)
+        alertController.addAction(signOutAction)
+        
+        present(alertController, animated: true)
     }
 }
 


### PR DESCRIPTION
# Description

Adds a bar button item to settings view that presents an alert to ask if user wants to sign out. If user selects sign out option and sign out is successful, authentication view is presented. Also fixes a bug where the collection view would be immediately instantiated even if user is signed out.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Change status

- [X] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [X] Ran on iPhoneXR simulator

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts