### PR TITLE
Fixes google sign in button constraints

### DIFF
--- a/ios/Anywhere Reader/Anywhere Reader/Resources/Storyboard/Authentication.storyboard
+++ b/ios/Anywhere Reader/Anywhere Reader/Resources/Storyboard/Authentication.storyboard
@@ -42,12 +42,12 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HCa-DY-0V3">
-                                <rect key="frame" x="30" y="264" width="354" height="368"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HCa-DY-0V3">
+                                <rect key="frame" x="30" y="255" width="354" height="386"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
-                            <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="flh-FK-sRZ">
-                                <rect key="frame" x="50" y="284" width="314" height="426"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="flh-FK-sRZ">
+                                <rect key="frame" x="50" y="275" width="314" height="346"/>
                                 <subviews>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="28u-EP-yQu">
                                         <rect key="frame" x="94.5" y="0.0" width="125" height="29"/>
@@ -60,8 +60,8 @@
                                             <action selector="toggleSignUp:" destination="Rcg-2l-HNe" eventType="valueChanged" id="AE9-IT-QiW"/>
                                         </connections>
                                     </segmentedControl>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="k3W-IO-gfk">
-                                        <rect key="frame" x="0.0" y="58" width="314" height="368"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="k3W-IO-gfk">
+                                        <rect key="frame" x="0.0" y="58" width="314" height="210"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="bT4-Oz-kWj">
                                                 <rect key="frame" x="0.0" y="0.0" width="314" height="30"/>
@@ -224,10 +224,6 @@
                                                 <rect key="frame" x="0.0" y="180" width="314" height="30"/>
                                                 <state key="normal" title="Sign Up"/>
                                             </button>
-                                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="F9b-bF-vhj" customClass="GIDSignInButton">
-                                                <rect key="frame" x="0.0" y="240" width="314" height="128"/>
-                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            </view>
                                         </subviews>
                                         <constraints>
                                             <constraint firstItem="zIo-zh-xvH" firstAttribute="height" secondItem="zrQ-0d-cmv" secondAttribute="height" id="3zF-gh-nTd"/>
@@ -238,6 +234,14 @@
                                             <constraint firstItem="VT2-z7-9c9" firstAttribute="height" secondItem="I4L-eQ-Jc4" secondAttribute="height" id="pjJ-NM-ifU"/>
                                         </constraints>
                                     </stackView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="F9b-bF-vhj" customClass="GIDSignInButton">
+                                        <rect key="frame" x="1" y="298" width="312" height="48"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="312" id="6cF-Y4-KRT"/>
+                                            <constraint firstAttribute="height" constant="48" id="A6P-2q-4Nt"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="k3W-IO-gfk" firstAttribute="width" secondItem="flh-FK-sRZ" secondAttribute="width" id="PSE-41-4hF"/>

--- a/ios/Anywhere Reader/Anywhere Reader/View Controller/Authentication/AuthenticationViewController.swift
+++ b/ios/Anywhere Reader/Anywhere Reader/View Controller/Authentication/AuthenticationViewController.swift
@@ -9,13 +9,15 @@
 import UIKit
 import GoogleSignIn
 
-class AuthenticationViewController: UIViewController, UITextFieldDelegate {
+class AuthenticationViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         GIDSignIn.sharedInstance().delegate = self
         GIDSignIn.sharedInstance().uiDelegate = self
+        
+        googleSignInButton.style = .wide
         
         updateViews()
     }
@@ -85,6 +87,7 @@ class AuthenticationViewController: UIViewController, UITextFieldDelegate {
         credentialsView.layer.shadowRadius = 10.0
         credentialsView.layer.shadowOffset = CGSize(width: 0.0, height: 0.0)
         credentialsView.layer.shadowOpacity = 1.0
+        credentialsView.layer.opacity = 0.75
     }
     
     /// Adds gradient to authenticateButton
@@ -201,10 +204,12 @@ class AuthenticationViewController: UIViewController, UITextFieldDelegate {
     private func authenticate() {
         
     }
-    
-    
-    // MARK: - UITextFieldDelegate
-    
+}
+
+
+// MARK: - UITextFieldDelegate
+
+extension AuthenticationViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         switch textField {
         case usernameTextField:
@@ -212,8 +217,8 @@ class AuthenticationViewController: UIViewController, UITextFieldDelegate {
         case emailTextField:
             passwordTextField.becomeFirstResponder()
         case passwordTextField:
-            authenticate()
             passwordTextField.resignFirstResponder()
+            authenticate()
         default:
             fatalError("No other textFields implemented")
         }


### PR DESCRIPTION
# Description

Changes googleSignInButton style to .wide. Sets constraints in interface builder to have a height of 48 and width of 312. Also puts textFieldShouldReturn func into an extension below the class declaration, and lowers the opacity of the credentials view background.

Fixes: googleSignInButton's constraints

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Change status

- [X] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [ ] Ran on iPhone XR simulator in all orientations
- [ ] Ran on iPhone 5s simulator in all orientations

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts