### PR TITLE
article modal

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -57,6 +57,7 @@ coverage.xml
 *.log
 local_settings.py
 db.sqlite3
+requirements.txt
 
 # Flask stuff:
 instance/

--- a/frontend/src/components/App/App.js
+++ b/frontend/src/components/App/App.js
@@ -1,14 +1,16 @@
 import React, { Component } from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
-import TestScraperFormContainer from '../../containers/TestScraperFormContainer';
-import LandingPage from '../LandingPage/LandingPage';
+// import styled from 'styled-components';
+
+import { TestScraperFormContainer } from '../../containers';
 import {
 	SignInPage,
 	SignUpPage,
 	SignedIn,
 	SignedUp,
 	Navi,
-	StripeProviderStub
+	StripeProviderStub,
+	LandingPage
 } from '../';
 
 class App extends Component {
@@ -17,13 +19,11 @@ class App extends Component {
 			<Router>
 				<div>
 					<Navi />
-					{/* <TestScraperFormContainer /> */}
-					{/* <Route exact to="/" component={} /> */}
 					<Route
 						path="/testScraperFormContainer"
 						component={TestScraperFormContainer}
 					/>
-					<Route path="/" component={LandingPage} />
+					<Route exact path="/" component={LandingPage} />
 					<Route path="/signIn" component={SignInPage} />
 					<Route path="/signUp" component={SignUpPage} />
 					<Route path="/signedIn" component={SignedIn} />

--- a/frontend/src/components/CheckoutForm/index.js
+++ b/frontend/src/components/CheckoutForm/index.js
@@ -1,1 +1,3 @@
+export { default as CheckoutForm } from './CheckoutForm';
+export { default as MyStoreCheckout } from './MyStoreCheckout';
 export { default as StripeProviderStub } from './StripeProviderStub';

--- a/frontend/src/components/LandingPage/index.js
+++ b/frontend/src/components/LandingPage/index.js
@@ -1,0 +1,1 @@
+export { default as LandingPage } from './LandingPage';

--- a/frontend/src/components/TestScraperForm/ArticleModal.js
+++ b/frontend/src/components/TestScraperForm/ArticleModal.js
@@ -1,0 +1,52 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+// import styled from 'styled-components';
+
+class ArticleModal extends Component {
+	render() {
+		console.log('pages:', this.props.pages);
+		return this.props.fetchingPages ? (
+			<div>
+				<p>Please wait while we retrieve the article. :)</p>
+			</div>
+		) : this.props.error !== '' ? (
+			<div>
+				<p>{this.props.error}</p>
+			</div>
+		) : (
+			<div>
+				<h4>{this.props.pages.title}</h4>
+				<h5>{`Authors: ${this.props.pages.author}`}</h5>
+				<p>{`Source: ${this.props.pages.resolved_url}`}</p>
+				<p>{`Saved: ${this.props.pages.date_saved}`}</p>
+				<br />
+				{this.props.pages.text}
+				<br />
+				<p>{`Tags: ${this.props.pages.tags}`}</p>
+			</div>
+		);
+	}
+}
+
+ArticleModal.propTypes = {
+	pages: PropTypes.arrayOf(
+		PropTypes.shape({
+			id: PropTypes.number,
+			title: PropTypes.string,
+			author: PropTypes.string,
+			normal_url: PropTypes.string,
+			resolved_url: PropTypes.string,
+			date_saved: PropTypes.string,
+			date_published: PropTypes.string,
+			excerpt: PropTypes.string,
+			cover_image: PropTypes.string,
+			tags: PropTypes.string,
+			text: PropTypes.string
+		})
+	),
+	pagesFetched: PropTypes.bool,
+	fetchingPages: PropTypes.bool,
+	error: PropTypes.string
+};
+
+export default ArticleModal;

--- a/frontend/src/components/TestScraperForm/ArticleModal.js
+++ b/frontend/src/components/TestScraperForm/ArticleModal.js
@@ -9,7 +9,6 @@ const CloseBtn = styled.h5`
 
 class ArticleModal extends Component {
 	render() {
-		console.log('pages:', this.props.pages);
 		return (
 			<div>
 				<CloseBtn onClick={() => this.props.closeModal()}>X</CloseBtn>

--- a/frontend/src/components/TestScraperForm/ArticleModal.js
+++ b/frontend/src/components/TestScraperForm/ArticleModal.js
@@ -1,52 +1,47 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-// import styled from 'styled-components';
+import styled from 'styled-components';
+
+const CloseBtn = styled.h5`
+	font-weight: bold;
+	cursor: pointer;
+`;
 
 class ArticleModal extends Component {
 	render() {
 		console.log('pages:', this.props.pages);
-		return this.props.fetchingPages ? (
+		return (
 			<div>
-				<p>Please wait while we retrieve the article. :)</p>
-			</div>
-		) : this.props.error !== '' ? (
-			<div>
-				<p>{this.props.error}</p>
-			</div>
-		) : (
-			<div>
-				<h4>{this.props.pages.title}</h4>
-				<h5>{`Authors: ${this.props.pages.author}`}</h5>
-				<p>{`Source: ${this.props.pages.resolved_url}`}</p>
-				<p>{`Saved: ${this.props.pages.date_saved}`}</p>
+				<CloseBtn onClick={() => this.props.closeModal()}>X</CloseBtn>
+				<h4>{this.props.page.title}</h4>
+				<h5>{`Authors: ${this.props.page.author}`}</h5>
+				<p>{`Source: ${this.props.page.resolved_url}`}</p>
+				<p>{`Saved: ${this.props.page.date_saved}`}</p>
 				<br />
-				{this.props.pages.text}
+				{this.props.page.text}
 				<br />
-				<p>{`Tags: ${this.props.pages.tags}`}</p>
+				<br />
+				<p>{`Tags: ${this.props.page.tags}`}</p>
 			</div>
 		);
 	}
 }
 
 ArticleModal.propTypes = {
-	pages: PropTypes.arrayOf(
-		PropTypes.shape({
-			id: PropTypes.number,
-			title: PropTypes.string,
-			author: PropTypes.string,
-			normal_url: PropTypes.string,
-			resolved_url: PropTypes.string,
-			date_saved: PropTypes.string,
-			date_published: PropTypes.string,
-			excerpt: PropTypes.string,
-			cover_image: PropTypes.string,
-			tags: PropTypes.string,
-			text: PropTypes.string
-		})
-	),
-	pagesFetched: PropTypes.bool,
-	fetchingPages: PropTypes.bool,
-	error: PropTypes.string
+	page: PropTypes.shape({
+		id: PropTypes.number,
+		title: PropTypes.string,
+		author: PropTypes.string,
+		normal_url: PropTypes.string,
+		resolved_url: PropTypes.string,
+		date_saved: PropTypes.string,
+		date_published: PropTypes.string,
+		excerpt: PropTypes.string,
+		cover_image: PropTypes.string,
+		tags: PropTypes.string,
+		text: PropTypes.string
+	}).isRequired,
+	closeModal: PropTypes.func.isRequired
 };
 
 export default ArticleModal;

--- a/frontend/src/components/TestScraperForm/ArticleModal.js
+++ b/frontend/src/components/TestScraperForm/ArticleModal.js
@@ -15,7 +15,12 @@ class ArticleModal extends Component {
 				<CloseBtn onClick={() => this.props.closeModal()}>X</CloseBtn>
 				<h4>{this.props.page.title}</h4>
 				<h5>{`Authors: ${this.props.page.author}`}</h5>
-				<p>{`Source: ${this.props.page.resolved_url}`}</p>
+				<p>
+					{'Source: '}
+					<a href={`${this.props.page.normal_url}`}>
+						{this.props.page.normal_url}
+					</a>
+				</p>
 				<p>{`Saved: ${this.props.page.date_saved}`}</p>
 				<br />
 				{this.props.page.text}

--- a/frontend/src/components/TestScraperForm/Page.js
+++ b/frontend/src/components/TestScraperForm/Page.js
@@ -2,7 +2,7 @@ import React from 'react';
 // import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import { ArticleModal } from './';
+// import { ArticleModal } from './';
 
 const PageCardContainer = styled.div`
 	border-radius: 5px;

--- a/frontend/src/components/TestScraperForm/Page.js
+++ b/frontend/src/components/TestScraperForm/Page.js
@@ -1,5 +1,5 @@
-import React from 'react';
-// import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const PageCardContainer = styled.div`
@@ -10,15 +10,36 @@ const PageCardContainer = styled.div`
 	box-shadow: 0px 0px 30px -3px rgba(0, 0, 0, 0.75);
 `;
 
-const Page = props => {
-	return (
-		<PageCardContainer>
-			<img src={props.page.cover_image} width="100%" alt="" />
-			<h2>{props.page.title}</h2>
-		</PageCardContainer>
-	);
-};
+class Page extends Component {
+	clickPreview = () => {
+		this.props.modalPage(this.props.page);
+	};
 
-// Page.propTypes = {};
+	render() {
+		return (
+			<PageCardContainer onClick={this.clickPreview}>
+				<img src={this.props.page.cover_image} width="100%" alt="" />
+				<h2>{this.props.page.title}</h2>
+			</PageCardContainer>
+		);
+	}
+}
+
+Page.propTypes = {
+	page: PropTypes.shape({
+		id: PropTypes.number,
+		title: PropTypes.string,
+		author: PropTypes.string,
+		normal_url: PropTypes.string,
+		resolved_url: PropTypes.string,
+		date_saved: PropTypes.string,
+		date_published: PropTypes.string,
+		excerpt: PropTypes.string,
+		cover_image: PropTypes.string,
+		tags: PropTypes.string,
+		text: PropTypes.string
+	}),
+	modalPage: PropTypes.func
+};
 
 export default Page;

--- a/frontend/src/components/TestScraperForm/Page.js
+++ b/frontend/src/components/TestScraperForm/Page.js
@@ -1,5 +1,8 @@
 import React from 'react';
+// import PropTypes from 'prop-types';
 import styled from 'styled-components';
+
+import { ArticleModal } from './';
 
 const PageCardContainer = styled.div`
 	border-radius: 5px;

--- a/frontend/src/components/TestScraperForm/Page.js
+++ b/frontend/src/components/TestScraperForm/Page.js
@@ -2,8 +2,6 @@ import React from 'react';
 // import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-// import { ArticleModal } from './';
-
 const PageCardContainer = styled.div`
 	border-radius: 5px;
 	margin: 3rem;
@@ -20,5 +18,7 @@ const Page = props => {
 		</PageCardContainer>
 	);
 };
+
+// Page.propTypes = {};
 
 export default Page;

--- a/frontend/src/components/TestScraperForm/PageList.js
+++ b/frontend/src/components/TestScraperForm/PageList.js
@@ -1,23 +1,25 @@
-import React from 'react';
-import Page from './Page';
-
+import React, { Component } from 'react';
 import styled from 'styled-components';
+
+import { Page } from './';
 
 const PageListContainer = styled.div`
 	display: flex;
 	flex-direction: column;
 `;
 
-const PageList = props => {
-	console.log('props are:', props);
-	return (
-		<PageListContainer>
-			<h1>Your Pages:</h1>
-			{props.pages.map(page => {
-				return <Page page={page} key={page.id} />;
-			})}
-		</PageListContainer>
-	);
-};
+class PageList extends Component {
+	render() {
+		console.log('props are:', this.props);
+		return (
+			<PageListContainer>
+				<h1>Your Pages:</h1>
+				{this.props.pages.map(page => {
+					return <Page page={page} key={page.id} />;
+				})}
+			</PageListContainer>
+		);
+	}
+}
 
 export default PageList;

--- a/frontend/src/components/TestScraperForm/PageList.js
+++ b/frontend/src/components/TestScraperForm/PageList.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import styled from 'styled-components';
+import PropTypes from 'prop-types';
 
 import { Page } from './';
 
@@ -15,11 +16,32 @@ class PageList extends Component {
 			<PageListContainer>
 				<h1>Your Pages:</h1>
 				{this.props.pages.map(page => {
-					return <Page page={page} key={page.id} />;
+					return (
+						<Page page={page} modalPage={this.props.modalPage} key={page.id} />
+					);
 				})}
 			</PageListContainer>
 		);
 	}
 }
+
+PageList.propTypes = {
+	pages: PropTypes.arrayOf(
+		PropTypes.shape({
+			id: PropTypes.number,
+			title: PropTypes.string,
+			author: PropTypes.string,
+			normal_url: PropTypes.string,
+			resolved_url: PropTypes.string,
+			date_saved: PropTypes.string,
+			date_published: PropTypes.string,
+			excerpt: PropTypes.string,
+			cover_image: PropTypes.string,
+			tags: PropTypes.string,
+			text: PropTypes.string
+		})
+	).isRequired,
+	modalPage: PropTypes.func
+};
 
 export default PageList;

--- a/frontend/src/components/TestScraperForm/TestScraper.js
+++ b/frontend/src/components/TestScraperForm/TestScraper.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react';
+
+import { PageList, TestScraperForm } from './';
+
+class TestScraper extends Component {
+	render() {
+		return (
+			<div>
+				<TestScraperForm
+					inputData={this.props.inputData}
+					handleInput={this.props.handleInput}
+					handleURL={this.props.handleURL}
+				/>
+				<PageList
+					pages={this.props.pages}
+					showingModal={this.props.showingModal}
+				/>
+			</div>
+		);
+	}
+}
+
+export default TestScraper;

--- a/frontend/src/components/TestScraperForm/TestScraper.js
+++ b/frontend/src/components/TestScraperForm/TestScraper.js
@@ -1,23 +1,65 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
-import { PageList, TestScraperForm } from './';
+import { ArticleModal, PageList, TestScraperForm } from './';
 
 class TestScraper extends Component {
+	state = {
+		page: {},
+		showingModal: false
+	};
+
+	closeModal = () => {
+		this.setState({
+			...this.state,
+			page: {},
+			showingModal: false
+		});
+	};
+
+	modalPage = page => {
+		this.setState({
+			...this.state,
+			page,
+			showingModal: true
+		});
+	};
+
 	render() {
-		return (
+		return this.state.showingModal ? (
+			<div>
+				<ArticleModal page={this.state.page} closeModal={this.closeModal} />
+			</div>
+		) : (
 			<div>
 				<TestScraperForm
-					inputData={this.props.inputData}
-					handleInput={this.props.handleInput}
-					handleURL={this.props.handleURL}
+					sendUrl={this.props.sendUrl}
+					serverToken={this.props.serverToken}
 				/>
-				<PageList
-					pages={this.props.pages}
-					showingModal={this.props.showingModal}
-				/>
+				<PageList pages={this.props.pages} modalPage={this.modalPage} />
 			</div>
 		);
 	}
 }
+
+TestScraper.propTypes = {
+	pages: PropTypes.arrayOf(
+		PropTypes.shape({
+			id: PropTypes.number,
+			title: PropTypes.string,
+			author: PropTypes.string,
+			normal_url: PropTypes.string,
+			resolved_url: PropTypes.string,
+			date_saved: PropTypes.string,
+			date_published: PropTypes.string,
+			excerpt: PropTypes.string,
+			cover_image: PropTypes.string,
+			tags: PropTypes.string,
+			text: PropTypes.string
+		})
+	).isRequired,
+	serverToken: PropTypes.string.isRequired,
+	sendUrl: PropTypes.func.isRequired
+};
 
 export default TestScraper;

--- a/frontend/src/components/TestScraperForm/TestScraperForm.js
+++ b/frontend/src/components/TestScraperForm/TestScraperForm.js
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { Component } from 'react';
 import styled from 'styled-components';
+// import PropTypes from 'prop-types';
+
 const Container = styled.div`
 	text-align: center;
 	font-family: 'Roboto', sans-serif;
@@ -9,22 +11,61 @@ const Form = styled.form`
 	border-radius: 40px;
 `;
 
-const TestScraperForm = props => {
-	return (
-		<Container>
-			<Form>
-				Input Article URL here:
-				<input
-					type="text"
-					name="url"
-					placeholder="www.cnn.com"
-					value={props.inputData.url}
-					onChange={props.handleInput}
-				/>
-				<button onClick={props.handleURL}>Save Article</button>
-			</Form>
-		</Container>
-	);
-};
+class TestScraperForm extends Component {
+	state = {
+		inputData: {
+			url: ''
+		}
+	};
+
+	handleInput = event => {
+		//Event handler for when you start typing in a form
+		this.setState({
+			...this.state,
+			inputData: {
+				...this.state.inputData,
+				[event.target.name]: event.target.value
+			}
+		});
+	};
+
+	handleURL = event => {
+		//Event handler for when you click a button that you want to trigger info added
+		event.preventDefault();
+		this.props.sendURL(this.state.inputData, this.props.serverToken);
+		console.log('inputData:', this.state.inputData);
+		this.resetForm();
+	};
+
+	resetForm() {
+		this.setState({
+			...this.state,
+			inputData: {
+				...this.state.inputData,
+				url: ''
+			}
+		});
+	}
+
+	render() {
+		return (
+			<Container>
+				<Form>
+					Input Article URL here:
+					<input
+						type="text"
+						name="url"
+						placeholder="www.cnn.com"
+						value={this.state.inputData.url}
+						onChange={this.handleInput}
+					/>
+					<button onClick={this.handleURL}>Save Article</button>
+				</Form>
+			</Container>
+		);
+	}
+}
+
+// TestScraperForm.propTypes = {};
 
 export default TestScraperForm;

--- a/frontend/src/components/TestScraperForm/TestScraperForm.js
+++ b/frontend/src/components/TestScraperForm/TestScraperForm.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import styled from 'styled-components';
-// import PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 
 const Container = styled.div`
 	text-align: center;
@@ -32,7 +32,7 @@ class TestScraperForm extends Component {
 	handleURL = event => {
 		//Event handler for when you click a button that you want to trigger info added
 		event.preventDefault();
-		this.props.sendURL(this.state.inputData, this.props.serverToken);
+		this.props.sendUrl(this.state.inputData, this.props.serverToken);
 		console.log('inputData:', this.state.inputData);
 		this.resetForm();
 	};
@@ -66,6 +66,9 @@ class TestScraperForm extends Component {
 	}
 }
 
-// TestScraperForm.propTypes = {};
+TestScraperForm.propTypes = {
+	serverToken: PropTypes.string.isRequired,
+	sendUrl: PropTypes.func.isRequired
+};
 
 export default TestScraperForm;

--- a/frontend/src/components/TestScraperForm/index.js
+++ b/frontend/src/components/TestScraperForm/index.js
@@ -1,4 +1,4 @@
 export { default as Page } from './Page';
 export { default as PageList } from './PageList';
 export { default as TestScraperForm } from './TestScraperForm';
-export { default as ArticleModal } from './ArticleModal';
+// export { default as ArticleModal } from './ArticleModal';

--- a/frontend/src/components/TestScraperForm/index.js
+++ b/frontend/src/components/TestScraperForm/index.js
@@ -1,4 +1,5 @@
+export { default as ArticleModal } from './ArticleModal';
 export { default as Page } from './Page';
 export { default as PageList } from './PageList';
+export { default as TestScraper } from './TestScraper';
 export { default as TestScraperForm } from './TestScraperForm';
-// export { default as ArticleModal } from './ArticleModal';

--- a/frontend/src/components/TestScraperForm/index.js
+++ b/frontend/src/components/TestScraperForm/index.js
@@ -1,6 +1,4 @@
 export { default as Page } from './Page';
 export { default as PageList } from './PageList';
 export { default as TestScraperForm } from './TestScraperForm';
-export {
-	default as TestScraperFormContainer
-} from './TestScraperFormContainer';
+export { default as ArticleModal } from './ArticleModal';

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -1,8 +1,18 @@
-export { SignInPage, SignedIn } from './SignInPage';
-export { SignUpPage, SignedUp } from './SignUpPage';
 export { App } from './App';
-export { Navi } from './Navi';
+export {
+	CheckoutForm,
+	MyStoreCheckout,
+	StripeProviderStub
+} from './CheckoutForm';
 export { GoogleAuth } from './GoogleAuth';
-export { StripeProviderStub } from './CheckoutForm';
 export { LandingPage } from './LandingPage';
-export { TestScraperForm, PageList } from './TestScraperForm';
+export { Navi } from './Navi';
+export { SignedIn, SignInPage } from './SignInPage';
+export { SignedUp, SignUpPage } from './SignUpPage';
+export {
+	ArticleModal,
+	Page,
+	PageList,
+	TestScraper,
+	TestScraperForm
+} from './TestScraperForm';

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -4,3 +4,5 @@ export { App } from './App';
 export { Navi } from './Navi';
 export { GoogleAuth } from './GoogleAuth';
 export { StripeProviderStub } from './CheckoutForm';
+export { LandingPage } from './LandingPage';
+export { TestScraperForm, PageList } from './TestScraperForm';

--- a/frontend/src/containers/TestScraperFormContainer.js
+++ b/frontend/src/containers/TestScraperFormContainer.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { sendURL, fetchPages } from '../store/actions/testScraperFormActions';
-import PageList from '../components/TestScraperForm/PageList';
-import TestScraperForm from '../components/TestScraperForm/TestScraperForm';
+import { sendURL, fetchPages } from '../store/actions';
+
+import { PageList, TestScraperForm } from '../components';
 
 class TestScraperFormContainer extends Component {
 	state = {
@@ -29,7 +29,7 @@ class TestScraperFormContainer extends Component {
 		//Event handler for when you click a button that you want to trigger info added
 		event.preventDefault();
 		this.props.sendURL(this.state.inputData);
-		console.log('inputData:' + this.state.inputData);
+		console.log('inputData:', this.state.inputData);
 		this.resetForm();
 	};
 
@@ -55,7 +55,10 @@ class TestScraperFormContainer extends Component {
 					handleInput={this.handleInput}
 					handleURL={this.handleURL}
 				/>
-				<PageList pages={this.props.pages} />
+				<PageList
+					pages={this.props.pages}
+					showingModal={this.props.showingModal}
+				/>
 				{/* </React.Fragment>
 				)} */}
 			</div>
@@ -66,12 +69,13 @@ class TestScraperFormContainer extends Component {
 const mapStateToProps = state => {
 	return {
 		//Mps actions and reducers to the state
-		fetchingPages: state.testScraperFormReducers.fetchingPages,
-		pagesFetched: state.testScraperFormReducers.pagesFetched,
-		sendingURL: state.testScraperFormReducers.sendingURL,
-		urlSent: state.testScraperFormReducers.urlSent,
+		// fetchingPages: state.testScraperFormReducers.fetchingPages,
+		// pagesFetched: state.testScraperFormReducers.pagesFetched,
+		// sendingURL: state.testScraperFormReducers.sendingURL,
+		// urlSent: state.testScraperFormReducers.urlSent,
 		pages: state.testScraperFormReducers.pages,
-		error: state.testScraperFormReducers.error
+		// error: state.testScraperFormReducers.error,
+		showingModal: state.testScraperFormReducers.showingModal
 	};
 };
 

--- a/frontend/src/containers/TestScraperFormContainer.js
+++ b/frontend/src/containers/TestScraperFormContainer.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { sendURL, fetchPages } from '../store/actions';
+import PropTypes from 'prop-types';
+import { fetchPages, sendUrl } from '../store/actions';
 
 import { TestScraper } from '../components';
 
@@ -20,6 +21,27 @@ class TestScraperFormContainer extends Component {
 	}
 }
 
+TestScraperFormContainer.propTypes = {
+	pages: PropTypes.arrayOf(
+		PropTypes.shape({
+			id: PropTypes.number,
+			title: PropTypes.string,
+			author: PropTypes.string,
+			normal_url: PropTypes.string,
+			resolved_url: PropTypes.string,
+			date_saved: PropTypes.string,
+			date_published: PropTypes.string,
+			excerpt: PropTypes.string,
+			cover_image: PropTypes.string,
+			tags: PropTypes.string,
+			text: PropTypes.string
+		})
+	).isRequired,
+	serverToken: PropTypes.string.isRequired,
+	fetchPages: PropTypes.func.isRequired,
+	sendUrl: PropTypes.func.isRequired
+};
+
 const mapStateToProps = state => {
 	return {
 		//Mps actions and reducers to the state
@@ -29,7 +51,6 @@ const mapStateToProps = state => {
 		// urlSent: state.testScraperFormReducers.urlSent,
 		pages: state.testScraperFormReducers.pages,
 		// error: state.testScraperFormReducers.error,
-		showingModal: state.testScraperFormReducers.showingModal,
 		serverToken: state.userReducers.auth.serverToken
 	};
 };
@@ -38,6 +59,6 @@ export default connect(
 	mapStateToProps,
 	{
 		fetchPages,
-		sendURL
+		sendUrl
 	}
 )(TestScraperFormContainer);

--- a/frontend/src/containers/TestScraperFormContainer.js
+++ b/frontend/src/containers/TestScraperFormContainer.js
@@ -2,65 +2,19 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { sendURL, fetchPages } from '../store/actions';
 
-import { PageList, TestScraperForm } from '../components';
+import { TestScraper } from '../components';
 
 class TestScraperFormContainer extends Component {
-	state = {
-		inputData: {
-			url: ''
-		}
-	};
-
 	componentDidMount() {
 		this.props.fetchPages(this.props.serverToken);
-	}
-
-	handleInput = event => {
-		//Event handler for when you start typing in a form
-		this.setState({
-			inputData: {
-				...this.state.inputData,
-				[event.target.name]: event.target.value
-			}
-		});
-	};
-
-	handleURL = event => {
-		//Event handler for when you click a button that you want to trigger info added
-		event.preventDefault();
-		this.props.sendURL(this.state.inputData, this.props.serverToken);
-		console.log('inputData:', this.state.inputData);
-		this.resetForm();
-	};
-
-	resetForm() {
-		this.setState({
-			inputData: {
-				url: ''
-			}
-		});
 	}
 
 	render() {
 		return (
 			<div>
-				{/* {!this.props.pagesFetched ? (
-					<h1>Loading Articles Please Wait...</h1>
-				) : (
-					<React.Fragment> */}
 				<br />
 				<br />
-				<TestScraperForm
-					inputData={this.state.inputData}
-					handleInput={this.handleInput}
-					handleURL={this.handleURL}
-				/>
-				<PageList
-					pages={this.props.pages}
-					showingModal={this.props.showingModal}
-				/>
-				{/* </React.Fragment>
-				)} */}
+				<TestScraper {...this.props} />
 			</div>
 		);
 	}

--- a/frontend/src/containers/TestScraperFormContainer.js
+++ b/frontend/src/containers/TestScraperFormContainer.js
@@ -12,7 +12,7 @@ class TestScraperFormContainer extends Component {
 	};
 
 	componentDidMount() {
-		this.props.fetchPages();
+		this.props.fetchPages(this.props.serverToken);
 	}
 
 	handleInput = event => {
@@ -28,7 +28,7 @@ class TestScraperFormContainer extends Component {
 	handleURL = event => {
 		//Event handler for when you click a button that you want to trigger info added
 		event.preventDefault();
-		this.props.sendURL(this.state.inputData);
+		this.props.sendURL(this.state.inputData, this.props.serverToken);
 		console.log('inputData:', this.state.inputData);
 		this.resetForm();
 	};
@@ -75,7 +75,8 @@ const mapStateToProps = state => {
 		// urlSent: state.testScraperFormReducers.urlSent,
 		pages: state.testScraperFormReducers.pages,
 		// error: state.testScraperFormReducers.error,
-		showingModal: state.testScraperFormReducers.showingModal
+		showingModal: state.testScraperFormReducers.showingModal,
+		serverToken: state.userReducers.auth.serverToken
 	};
 };
 

--- a/frontend/src/containers/index.js
+++ b/frontend/src/containers/index.js
@@ -1,1 +1,4 @@
 export { default as GoogleAuthContainer } from './GoogleAuthContainer';
+export {
+	default as TestScraperFormContainer
+} from './TestScraperFormContainer';

--- a/frontend/src/store/actions/index.js
+++ b/frontend/src/store/actions/index.js
@@ -1,3 +1,8 @@
+export const apiBaseUrl =
+	process.env.NODE_ENV === 'production'
+		? 'https://anywhere-reader-test.herokuapp.com'
+		: 'http://localhost:8000';
+
 export {
 	ADD_ARTICLE,
 	DELETE_ARTICLE,
@@ -7,6 +12,20 @@ export {
 	addArticle,
 	deleteArticle
 } from './articleActions';
+
+export {
+	FETCHING_PAGES,
+	PAGES_FETCHED,
+	PAGES_FETCH_ERROR,
+	INITIALIZE_URL_SUBMIT,
+	COMPLETE_URL_SUBMIT,
+	SUBMIT_URL_ERROR,
+	TOGGLE_MODAL,
+	fetchPages,
+	toggleModal,
+	sendURL
+} from './testScraperFormActions';
+
 export {
 	REGISTER_USER,
 	LOGGING_IN_USER,
@@ -22,16 +41,3 @@ export {
 	fetchUser,
 	premiumUser
 } from './userActions';
-export {
-	FETCHING_PAGES,
-	PAGES_FETCHED,
-	PAGES_FETCH_ERROR,
-	INITIALIZE_URL_SUBMIT,
-	COMPLETE_URL_SUBMIT,
-	SUBMIT_URL_ERROR
-} from './testScraperFormActions';
-
-export const apiBaseUrl =
-	process.env.NODE_ENV === 'production'
-		? 'https://anywhere-reader-test.herokuapp.com/api'
-		: 'http://localhost:8000/api';

--- a/frontend/src/store/actions/index.js
+++ b/frontend/src/store/actions/index.js
@@ -20,10 +20,8 @@ export {
 	INITIALIZE_URL_SUBMIT,
 	COMPLETE_URL_SUBMIT,
 	SUBMIT_URL_ERROR,
-	TOGGLE_MODAL,
 	fetchPages,
-	toggleModal,
-	sendURL
+	sendUrl
 } from './testScraperFormActions';
 
 export {

--- a/frontend/src/store/actions/testScraperFormActions.js
+++ b/frontend/src/store/actions/testScraperFormActions.js
@@ -7,7 +7,6 @@ export const PAGES_FETCH_ERROR = 'PAGES_FETCH_ERROR';
 export const INITIALIZE_URL_SUBMIT = 'INITIALIZE_URL_SUBMIT';
 export const COMPLETE_URL_SUBMIT = 'COMPLETE_URL_SUBMIT';
 export const SUBMIT_URL_ERROR = 'SUBMIT_URL_ERROR';
-export const TOGGLE_MODAL = 'TOGGLE_MODAL';
 
 export const fetchPages = serverToken => {
 	return dispatch => {
@@ -37,9 +36,7 @@ export const fetchPages = serverToken => {
 	};
 };
 
-export const toggleModal = () => {};
-
-export const sendURL = (newURL, serverToken) => {
+export const sendUrl = (newURL, serverToken) => {
 	return dispatch => {
 		//Again, action to indicate an API call is about to be made, this time for a POST
 		dispatch({ type: INITIALIZE_URL_SUBMIT });

--- a/frontend/src/store/actions/testScraperFormActions.js
+++ b/frontend/src/store/actions/testScraperFormActions.js
@@ -9,13 +9,13 @@ export const COMPLETE_URL_SUBMIT = 'COMPLETE_URL_SUBMIT';
 export const SUBMIT_URL_ERROR = 'SUBMIT_URL_ERROR';
 export const TOGGLE_MODAL = 'TOGGLE_MODAL';
 
-export const fetchPages = () => {
+export const fetchPages = serverToken => {
 	return dispatch => {
 		//Action that indicates data is being fetched
 		dispatch({ type: FETCHING_PAGES });
 		let headers = {
 			'Content-Type': 'application/json',
-			Authorization: 'Token e5f6efffdaf49d83381c94a7a322266e77013428'
+			Authorization: `Token ${serverToken}`
 		};
 		//TODO: remove hard coded auth header
 		axios
@@ -39,14 +39,14 @@ export const fetchPages = () => {
 
 export const toggleModal = () => {};
 
-export const sendURL = newURL => {
+export const sendURL = (newURL, serverToken) => {
 	return dispatch => {
 		//Again, action to indicate an API call is about to be made, this time for a POST
 		dispatch({ type: INITIALIZE_URL_SUBMIT });
 		//Below, you're making the POST call to the API, with newURL as the object youre sending.
 		let headers = {
 			'Content-Type': 'application/json',
-			Authorization: 'Token e5f6efffdaf49d83381c94a7a322266e77013428'
+			Authorization: `Token ${serverToken}`
 		};
 		axios
 			.post(`${apiBaseUrl}/api/scrape/`, newURL, {

--- a/frontend/src/store/actions/testScraperFormActions.js
+++ b/frontend/src/store/actions/testScraperFormActions.js
@@ -1,10 +1,13 @@
 import axios from 'axios';
+import { apiBaseUrl } from './';
+
 export const FETCHING_PAGES = 'FETCHING_PAGES';
 export const PAGES_FETCHED = 'PAGES_FETCHED';
 export const PAGES_FETCH_ERROR = 'PAGES_FETCH_ERROR';
 export const INITIALIZE_URL_SUBMIT = 'INITIALIZE_URL_SUBMIT';
 export const COMPLETE_URL_SUBMIT = 'COMPLETE_URL_SUBMIT';
 export const SUBMIT_URL_ERROR = 'SUBMIT_URL_ERROR';
+export const TOGGLE_MODAL = 'TOGGLE_MODAL';
 
 export const fetchPages = () => {
 	return dispatch => {
@@ -16,11 +19,11 @@ export const fetchPages = () => {
 		};
 		//TODO: remove hard coded auth header
 		axios
-			.get('https://anywhere-reader-test.herokuapp.com/pages/', {
+			.get(`${apiBaseUrl}/pages/`, {
 				headers: headers
 			})
 			.then(response => {
-				// console.log('response:' + JSON.stringify(response.data));
+				// console.log('response:', JSON.stringify(response.data));
 
 				dispatch({
 					type: PAGES_FETCHED,
@@ -28,11 +31,13 @@ export const fetchPages = () => {
 				});
 			})
 			.catch(err => {
-				console.log(err);
+				console.error(err);
 				dispatch({ type: PAGES_FETCH_ERROR });
 			});
 	};
 };
+
+export const toggleModal = () => {};
 
 export const sendURL = newURL => {
 	return dispatch => {
@@ -44,7 +49,7 @@ export const sendURL = newURL => {
 			Authorization: 'Token e5f6efffdaf49d83381c94a7a322266e77013428'
 		};
 		axios
-			.post('https://anywhere-reader-test.herokuapp.com/api/scrape/', newURL, {
+			.post(`${apiBaseUrl}/api/scrape/`, newURL, {
 				headers: headers
 			})
 			.then(response => {
@@ -52,11 +57,11 @@ export const sendURL = newURL => {
 				dispatch({ type: COMPLETE_URL_SUBMIT, payload: response.data });
 
 				axios
-					.get('https://anywhere-reader-test.herokuapp.com/pages/', {
+					.get(`${apiBaseUrl}/pages/`, {
 						headers: headers
 					})
 					.then(response => {
-						// console.log('response:' + JSON.stringify(response.data));
+						// console.log('response:', JSON.stringify(response.data));
 
 						dispatch({
 							type: PAGES_FETCHED,
@@ -65,7 +70,7 @@ export const sendURL = newURL => {
 					});
 			})
 			.catch(err => {
-				console.log(err);
+				console.error(err);
 				dispatch({ type: SUBMIT_URL_ERROR });
 			});
 	};

--- a/frontend/src/store/reducers/testScraperFormReducers.js
+++ b/frontend/src/store/reducers/testScraperFormReducers.js
@@ -16,7 +16,8 @@ const initialState = {
 	pagesFetched: false,
 	scraperResponse: [],
 	sendingURL: false,
-	error: ''
+	error: '',
+	showingModal: false
 };
 
 export const testScraperFormReducers = (state = initialState, action) => {

--- a/frontend/src/store/reducers/testScraperFormReducers.js
+++ b/frontend/src/store/reducers/testScraperFormReducers.js
@@ -7,8 +7,7 @@ import {
 	PAGES_FETCH_ERROR,
 	INITIALIZE_URL_SUBMIT,
 	COMPLETE_URL_SUBMIT,
-	SUBMIT_URL_ERROR,
-	TOGGLE_MODAL
+	SUBMIT_URL_ERROR
 } from '../actions';
 
 const initialState = {
@@ -17,8 +16,7 @@ const initialState = {
 	pagesFetched: false,
 	scraperResponse: [],
 	sendingURL: false,
-	error: '',
-	showingModal: false
+	error: ''
 };
 
 export const testScraperFormReducers = (state = initialState, action) => {
@@ -59,9 +57,6 @@ export const testScraperFormReducers = (state = initialState, action) => {
 				error: 'Error sending URL',
 				sendingURL: false
 			};
-
-		case TOGGLE_MODAL:
-			return { ...state, showingModal: !state.showingModal };
 
 		default:
 			return state;

--- a/frontend/src/store/reducers/testScraperFormReducers.js
+++ b/frontend/src/store/reducers/testScraperFormReducers.js
@@ -7,7 +7,8 @@ import {
 	PAGES_FETCH_ERROR,
 	INITIALIZE_URL_SUBMIT,
 	COMPLETE_URL_SUBMIT,
-	SUBMIT_URL_ERROR
+	SUBMIT_URL_ERROR,
+	TOGGLE_MODAL
 } from '../actions';
 
 const initialState = {
@@ -24,6 +25,7 @@ export const testScraperFormReducers = (state = initialState, action) => {
 	switch (action.type) {
 		case FETCHING_PAGES:
 			return { ...state, fetchingPages: true };
+
 		case PAGES_FETCHED:
 			return {
 				...state,
@@ -31,28 +33,36 @@ export const testScraperFormReducers = (state = initialState, action) => {
 				fetchingPages: false,
 				pagesFetched: true
 			};
+
 		case PAGES_FETCH_ERROR:
 			return {
 				...state,
 				error: 'Error fetching pages'
 			};
+
 		case INITIALIZE_URL_SUBMIT:
 			return {
 				...state,
 				sendingURL: true
 			};
+
 		case COMPLETE_URL_SUBMIT:
 			return {
 				...state,
 				sendingURL: false,
 				scraperResponse: action.payload
 			};
+
 		case SUBMIT_URL_ERROR:
 			return {
 				...state,
 				error: 'Error sending URL',
 				sendingURL: false
 			};
+
+		case TOGGLE_MODAL:
+			return { ...state, showingModal: !state.showingModal };
+
 		default:
 			return state;
 	}

--- a/frontend/src/store/reducers/userReducers.js
+++ b/frontend/src/store/reducers/userReducers.js
@@ -20,7 +20,7 @@ const initialState = {
 	auth: {
 		googleClientId:
 			'213031583666-fcjp2lmnht6pq13loo7ddo4s8r9lhvbr.apps.googleusercontent.com',
-		serverToken: ''
+		serverToken: 'e4d06c221480448a274af99806a6176e9bfd32a3'
 	},
 	userStatus: {
 		fetching: false,

--- a/frontend/src/store/reducers/userReducers.js
+++ b/frontend/src/store/reducers/userReducers.js
@@ -20,7 +20,7 @@ const initialState = {
 	auth: {
 		googleClientId:
 			'213031583666-fcjp2lmnht6pq13loo7ddo4s8r9lhvbr.apps.googleusercontent.com',
-		googleServerToken: ''
+		serverToken: ''
 	},
 	userStatus: {
 		fetching: false,
@@ -58,14 +58,14 @@ export default (state = initialState, action) => {
 		case LOGGING_IN_USER:
 			return {
 				...state,
-				auth: { ...state.auth, googleServerToken: '' },
+				auth: { ...state.auth, serverToken: '' },
 				userStatus: { ...state.userStatus, success: false }
 			};
 
 		case LOGGED_IN_USER:
 			return {
 				...state,
-				auth: { ...state.auth, googleServerToken: action.payload },
+				auth: { ...state.auth, serverToken: action.payload },
 				userStatus: { ...state.userStatus, success: true }
 			};
 
@@ -79,7 +79,7 @@ export default (state = initialState, action) => {
 					lastName: '',
 					premium: false
 				},
-				auth: { ...state.auth, googleServerToken: '' },
+				auth: { ...state.auth, serverToken: '' },
 				userStatus: { ...state.userStatus, success: false }
 			};
 


### PR DESCRIPTION
# Description

As part of the basic functionality, a modal was needed to show the full article when the preview tile was clicked on. This pull accomplishes this. It also normalizes the formatting of some of the associated components, container, and store pieces along with it.

Fixes # https://trello.com/c/Bs0yYFDX/182-create-page-modal-to-show-contents-of-a-given-page-in-the-frontend

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

On localhost, confirmed able to click on a preview tile, either with or without a preview image attached, and a modal of the full article would appear. Clicking the "X" on the modal would close it, bringing the user back to the preview tiles and scraper form view. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
