### PR TITLE
Main CoreData Setup

### DIFF
--- a/ios/Anywhere Reader/Anywhere Reader.xcodeproj/project.pbxproj
+++ b/ios/Anywhere Reader/Anywhere Reader.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		223E6F3821B5C0750024E993 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223E6F3721B5C0750024E993 /* CoreDataStack.swift */; };
 		223E6F3B21B5C08A0024E993 /* Anywhere Reader.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 223E6F3921B5C08A0024E993 /* Anywhere Reader.xcdatamodeld */; };
 		223E6F3D21B5C5B50024E993 /* Article+Encodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223E6F3C21B5C5B50024E993 /* Article+Encodable.swift */; };
+		223E6F3F21B5C8370024E993 /* Article+ConvenienceInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223E6F3E21B5C8370024E993 /* Article+ConvenienceInit.swift */; };
 		22661E07219240400072A4B8 /* ContentCollectionViewController+FlowLayoutDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22661E06219240400072A4B8 /* ContentCollectionViewController+FlowLayoutDelegate.swift */; };
 		22661E092192688D0072A4B8 /* DocumentCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22661E082192688D0072A4B8 /* DocumentCollectionViewCell.swift */; };
 		22661E102194E3A30072A4B8 /* VisualPreferencesPanel.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 22661E0F2194E3A30072A4B8 /* VisualPreferencesPanel.storyboard */; };
@@ -73,6 +74,7 @@
 		223E6F3721B5C0750024E993 /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
 		223E6F3A21B5C08A0024E993 /* Anywhere Reader.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Anywhere Reader.xcdatamodel"; sourceTree = "<group>"; };
 		223E6F3C21B5C5B50024E993 /* Article+Encodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Article+Encodable.swift"; sourceTree = "<group>"; };
+		223E6F3E21B5C8370024E993 /* Article+ConvenienceInit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Article+ConvenienceInit.swift"; sourceTree = "<group>"; };
 		22661E06219240400072A4B8 /* ContentCollectionViewController+FlowLayoutDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentCollectionViewController+FlowLayoutDelegate.swift"; sourceTree = "<group>"; };
 		22661E082192688D0072A4B8 /* DocumentCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentCollectionViewCell.swift; sourceTree = "<group>"; };
 		22661E0F2194E3A30072A4B8 /* VisualPreferencesPanel.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = VisualPreferencesPanel.storyboard; sourceTree = "<group>"; };
@@ -214,6 +216,7 @@
 				223E6F3921B5C08A0024E993 /* Anywhere Reader.xcdatamodeld */,
 				223E6F3721B5C0750024E993 /* CoreDataStack.swift */,
 				223E6F3C21B5C5B50024E993 /* Article+Encodable.swift */,
+				223E6F3E21B5C8370024E993 /* Article+ConvenienceInit.swift */,
 			);
 			path = "Core Data";
 			sourceTree = "<group>";
@@ -426,6 +429,7 @@
 				2200578B219DB8FB00808E4B /* AppearanceHelper.swift in Sources */,
 				13FB2E2C21921B8C00A8888B /* ArticleController.swift in Sources */,
 				13FB2E3321922CFA00A8888B /* AccountViewController.swift in Sources */,
+				223E6F3F21B5C8370024E993 /* Article+ConvenienceInit.swift in Sources */,
 				13B013DE219394AD00DA56B9 /* SegmentedSettingsViewController.swift in Sources */,
 				13FB2E3B21922DD000A8888B /* AuthenticationViewController.swift in Sources */,
 				13FB2E3721922D6100A8888B /* ContentDetailViewController.swift in Sources */,

--- a/ios/Anywhere Reader/Anywhere Reader.xcodeproj/project.pbxproj
+++ b/ios/Anywhere Reader/Anywhere Reader.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		2233F7D021920A09001A82FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2233F7CE21920A09001A82FF /* LaunchScreen.storyboard */; };
 		223E6F3821B5C0750024E993 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223E6F3721B5C0750024E993 /* CoreDataStack.swift */; };
 		223E6F3B21B5C08A0024E993 /* Anywhere Reader.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 223E6F3921B5C08A0024E993 /* Anywhere Reader.xcdatamodeld */; };
+		223E6F3D21B5C5B50024E993 /* Article+Encodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223E6F3C21B5C5B50024E993 /* Article+Encodable.swift */; };
 		22661E07219240400072A4B8 /* ContentCollectionViewController+FlowLayoutDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22661E06219240400072A4B8 /* ContentCollectionViewController+FlowLayoutDelegate.swift */; };
 		22661E092192688D0072A4B8 /* DocumentCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22661E082192688D0072A4B8 /* DocumentCollectionViewCell.swift */; };
 		22661E102194E3A30072A4B8 /* VisualPreferencesPanel.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 22661E0F2194E3A30072A4B8 /* VisualPreferencesPanel.storyboard */; };
@@ -71,6 +72,7 @@
 		2233F7D121920A09001A82FF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		223E6F3721B5C0750024E993 /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
 		223E6F3A21B5C08A0024E993 /* Anywhere Reader.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Anywhere Reader.xcdatamodel"; sourceTree = "<group>"; };
+		223E6F3C21B5C5B50024E993 /* Article+Encodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Article+Encodable.swift"; sourceTree = "<group>"; };
 		22661E06219240400072A4B8 /* ContentCollectionViewController+FlowLayoutDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentCollectionViewController+FlowLayoutDelegate.swift"; sourceTree = "<group>"; };
 		22661E082192688D0072A4B8 /* DocumentCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentCollectionViewCell.swift; sourceTree = "<group>"; };
 		22661E0F2194E3A30072A4B8 /* VisualPreferencesPanel.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = VisualPreferencesPanel.storyboard; sourceTree = "<group>"; };
@@ -209,8 +211,9 @@
 		223E6F3621B5C04F0024E993 /* Core Data */ = {
 			isa = PBXGroup;
 			children = (
-				223E6F3721B5C0750024E993 /* CoreDataStack.swift */,
 				223E6F3921B5C08A0024E993 /* Anywhere Reader.xcdatamodeld */,
+				223E6F3721B5C0750024E993 /* CoreDataStack.swift */,
+				223E6F3C21B5C5B50024E993 /* Article+Encodable.swift */,
 			);
 			path = "Core Data";
 			sourceTree = "<group>";
@@ -434,6 +437,7 @@
 				22661E092192688D0072A4B8 /* DocumentCollectionViewCell.swift in Sources */,
 				13FB2E3521922D1900A8888B /* ContentCollectionViewController.swift in Sources */,
 				13126F53219255A700A1ED13 /* AuthService.swift in Sources */,
+				223E6F3D21B5C5B50024E993 /* Article+Encodable.swift in Sources */,
 				22661E122194E5430072A4B8 /* PreferencesViewController.swift in Sources */,
 				2200578D219DC40100808E4B /* UserDefaultsThemeHelper.swift in Sources */,
 				222F5B8221A4D35B002B6436 /* UIView+GradientAndMask.swift in Sources */,

--- a/ios/Anywhere Reader/Anywhere Reader.xcodeproj/project.pbxproj
+++ b/ios/Anywhere Reader/Anywhere Reader.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		13B013DE219394AD00DA56B9 /* SegmentedSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B013DD219394AD00DA56B9 /* SegmentedSettingsViewController.swift */; };
 		13B013E0219394E300DA56B9 /* BillingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B013DF219394E300DA56B9 /* BillingViewController.swift */; };
 		13F945E421AF4CC80019A3D2 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13F945E321AF4CC80019A3D2 /* User.swift */; };
-		13FB2E2A21921B7D00A8888B /* Article.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FB2E2921921B7D00A8888B /* Article.swift */; };
+		13FB2E2A21921B7D00A8888B /* ArticleRep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FB2E2921921B7D00A8888B /* ArticleRep.swift */; };
 		13FB2E2C21921B8C00A8888B /* ArticleController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FB2E2B21921B8C00A8888B /* ArticleController.swift */; };
 		13FB2E2F21921CD200A8888B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 13FB2E2E21921CD200A8888B /* Main.storyboard */; };
 		13FB2E3121922C9F00A8888B /* Settings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 13FB2E3021922C9F00A8888B /* Settings.storyboard */; };
@@ -31,6 +31,8 @@
 		2233F7C621920A06001A82FF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2233F7C521920A06001A82FF /* AppDelegate.swift */; };
 		2233F7CD21920A09001A82FF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2233F7CC21920A09001A82FF /* Assets.xcassets */; };
 		2233F7D021920A09001A82FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2233F7CE21920A09001A82FF /* LaunchScreen.storyboard */; };
+		223E6F3821B5C0750024E993 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223E6F3721B5C0750024E993 /* CoreDataStack.swift */; };
+		223E6F3B21B5C08A0024E993 /* Anywhere Reader.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 223E6F3921B5C08A0024E993 /* Anywhere Reader.xcdatamodeld */; };
 		22661E07219240400072A4B8 /* ContentCollectionViewController+FlowLayoutDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22661E06219240400072A4B8 /* ContentCollectionViewController+FlowLayoutDelegate.swift */; };
 		22661E092192688D0072A4B8 /* DocumentCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22661E082192688D0072A4B8 /* DocumentCollectionViewCell.swift */; };
 		22661E102194E3A30072A4B8 /* VisualPreferencesPanel.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 22661E0F2194E3A30072A4B8 /* VisualPreferencesPanel.storyboard */; };
@@ -48,7 +50,7 @@
 		13B013DD219394AD00DA56B9 /* SegmentedSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedSettingsViewController.swift; sourceTree = "<group>"; };
 		13B013DF219394E300DA56B9 /* BillingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingViewController.swift; sourceTree = "<group>"; };
 		13F945E321AF4CC80019A3D2 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
-		13FB2E2921921B7D00A8888B /* Article.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Article.swift; sourceTree = "<group>"; };
+		13FB2E2921921B7D00A8888B /* ArticleRep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleRep.swift; sourceTree = "<group>"; };
 		13FB2E2B21921B8C00A8888B /* ArticleController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleController.swift; sourceTree = "<group>"; };
 		13FB2E2E21921CD200A8888B /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		13FB2E3021922C9F00A8888B /* Settings.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Settings.storyboard; sourceTree = "<group>"; };
@@ -67,6 +69,8 @@
 		2233F7CC21920A09001A82FF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2233F7CF21920A09001A82FF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		2233F7D121920A09001A82FF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		223E6F3721B5C0750024E993 /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
+		223E6F3A21B5C08A0024E993 /* Anywhere Reader.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Anywhere Reader.xcdatamodel"; sourceTree = "<group>"; };
 		22661E06219240400072A4B8 /* ContentCollectionViewController+FlowLayoutDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentCollectionViewController+FlowLayoutDelegate.swift"; sourceTree = "<group>"; };
 		22661E082192688D0072A4B8 /* DocumentCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentCollectionViewCell.swift; sourceTree = "<group>"; };
 		22661E0F2194E3A30072A4B8 /* VisualPreferencesPanel.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = VisualPreferencesPanel.storyboard; sourceTree = "<group>"; };
@@ -108,7 +112,7 @@
 		13FB2E2321921AA600A8888B /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				13FB2E2921921B7D00A8888B /* Article.swift */,
+				13FB2E2921921B7D00A8888B /* ArticleRep.swift */,
 				13F945E321AF4CC80019A3D2 /* User.swift */,
 			);
 			path = Model;
@@ -192,6 +196,7 @@
 				1332E69B21AC7957003413F6 /* GoogleService-Info.plist */,
 				2200578A219DB8FB00808E4B /* AppearanceHelper.swift */,
 				2200578C219DC40100808E4B /* UserDefaultsThemeHelper.swift */,
+				223E6F3621B5C04F0024E993 /* Core Data */,
 				13FB2E2321921AA600A8888B /* Model */,
 				13FB2E2621921AB600A8888B /* Model Controller */,
 				13FB2E2521921AAE00A8888B /* View Controller */,
@@ -199,6 +204,15 @@
 				13FB2E2821921AD400A8888B /* Resources */,
 			);
 			path = "Anywhere Reader";
+			sourceTree = "<group>";
+		};
+		223E6F3621B5C04F0024E993 /* Core Data */ = {
+			isa = PBXGroup;
+			children = (
+				223E6F3721B5C0750024E993 /* CoreDataStack.swift */,
+				223E6F3921B5C08A0024E993 /* Anywhere Reader.xcdatamodeld */,
+			);
+			path = "Core Data";
 			sourceTree = "<group>";
 		};
 		22661E0A219268940072A4B8 /* Content Collection */ = {
@@ -401,7 +415,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				223E6F3821B5C0750024E993 /* CoreDataStack.swift in Sources */,
 				2233F7C621920A06001A82FF /* AppDelegate.swift in Sources */,
+				223E6F3B21B5C08A0024E993 /* Anywhere Reader.xcdatamodeld in Sources */,
 				1373243121ADCCED006DDF1E /* APIService.swift in Sources */,
 				222F5B7F21A4D16E002B6436 /* GradientMaskView.swift in Sources */,
 				2200578B219DB8FB00808E4B /* AppearanceHelper.swift in Sources */,
@@ -414,7 +430,7 @@
 				13F945E421AF4CC80019A3D2 /* User.swift in Sources */,
 				222F5B8421A5E961002B6436 /* TrapezoidGradientView.swift in Sources */,
 				22661E07219240400072A4B8 /* ContentCollectionViewController+FlowLayoutDelegate.swift in Sources */,
-				13FB2E2A21921B7D00A8888B /* Article.swift in Sources */,
+				13FB2E2A21921B7D00A8888B /* ArticleRep.swift in Sources */,
 				22661E092192688D0072A4B8 /* DocumentCollectionViewCell.swift in Sources */,
 				13FB2E3521922D1900A8888B /* ContentCollectionViewController.swift in Sources */,
 				13126F53219255A700A1ED13 /* AuthService.swift in Sources */,
@@ -614,6 +630,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		223E6F3921B5C08A0024E993 /* Anywhere Reader.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				223E6F3A21B5C08A0024E993 /* Anywhere Reader.xcdatamodel */,
+			);
+			currentVersion = 223E6F3A21B5C08A0024E993 /* Anywhere Reader.xcdatamodel */;
+			path = "Anywhere Reader.xcdatamodeld";
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 2233F7BA21920A06001A82FF /* Project object */;
 }

--- a/ios/Anywhere Reader/Anywhere Reader/Core Data/Anywhere Reader.xcdatamodeld/Anywhere Reader.xcdatamodel/contents
+++ b/ios/Anywhere Reader/Anywhere Reader/Core Data/Anywhere Reader.xcdatamodeld/Anywhere Reader.xcdatamodel/contents
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18B75" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Article" representedClassName="Article" syncable="YES" codeGenerationType="class">
+        <attribute name="author" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="coverImage" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="coverImageInFileSystem" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="datePublished" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateSaved" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="excerpt" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="id" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="normalURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="resolvedURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tags" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="Article" positionX="-63" positionY="-18" width="128" height="225"/>
+    </elements>
+</model>

--- a/ios/Anywhere Reader/Anywhere Reader/Core Data/Article+ConvenienceInit.swift
+++ b/ios/Anywhere Reader/Anywhere Reader/Core Data/Article+ConvenienceInit.swift
@@ -1,0 +1,27 @@
+//
+//  Article+ConvenienceInit.swift
+//  Anywhere Reader
+//
+//  Created by Samantha Gatt on 12/3/18.
+//  Copyright © 2018 Samantha Gatt. All rights reserved.
+//
+
+import CoreData
+
+extension Article {
+    convenience init(fromRep articleRep: ArticleRep, context: NSManagedObjectContext = CoreDataStack.moc) {
+        self.init(context: context)
+        
+        self.id = Int32(articleRep.id)
+        self.title = articleRep.title
+        self.author = articleRep.title
+        self.normalURL = articleRep.normalURL
+        self.resolvedURL = articleRep.resolvedURL
+        self.dateSaved = articleRep.dateSaved
+        self.datePublished = articleRep.datePublished
+        self.excerpt = articleRep.excerpt
+        self.coverImage = articleRep.coverImage
+        self.tags = articleRep.tags
+        self.text = articleRep.text
+    }
+}

--- a/ios/Anywhere Reader/Anywhere Reader/Core Data/Article+Encodable.swift
+++ b/ios/Anywhere Reader/Anywhere Reader/Core Data/Article+Encodable.swift
@@ -1,0 +1,42 @@
+//
+//  Article+Encodable.swift
+//  Anywhere Reader
+//
+//  Created by Samantha Gatt on 12/3/18.
+//  Copyright © 2018 Samantha Gatt. All rights reserved.
+//
+
+import CoreData
+
+extension Article: Encodable {
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "id"
+        case title = "title"
+        case author = "author"
+        case normalURL = "normal_url"
+        case resolvedURL = "resolved_url"
+        case dateSaved = "date_saved"
+        case datePublished = "date_published"
+        case excerpt = "excerpt"
+        case coverImage = "cover_image"
+        case tags = "tags"
+        case text = "text"
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        try container.encode(id, forKey: .id)
+        try container.encode(title, forKey: .title)
+        try container.encode(author, forKey: .author)
+        try container.encode(normalURL, forKey: .normalURL)
+        try container.encode(resolvedURL, forKey: .resolvedURL)
+        try container.encode(dateSaved, forKey: .dateSaved)
+        try container.encode(datePublished, forKey: .datePublished)
+        try container.encode(excerpt, forKey: .excerpt)
+        try container.encode(coverImage, forKey: .coverImage)
+        try container.encode(tags, forKey: .tags)
+        try container.encode(text, forKey: .text)
+    }
+}

--- a/ios/Anywhere Reader/Anywhere Reader/Core Data/Article+Encodable.swift
+++ b/ios/Anywhere Reader/Anywhere Reader/Core Data/Article+Encodable.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Samantha Gatt. All rights reserved.
 //
 
-import CoreData
+import Foundation
 
 extension Article: Encodable {
     

--- a/ios/Anywhere Reader/Anywhere Reader/Core Data/CoreDataStack.swift
+++ b/ios/Anywhere Reader/Anywhere Reader/Core Data/CoreDataStack.swift
@@ -1,0 +1,31 @@
+//
+//  CoreDataStack.swift
+//  Anywhere Reader
+//
+//  Created by Samantha Gatt on 12/3/18.
+//  Copyright © 2018 Samantha Gatt. All rights reserved.
+//
+
+import CoreData
+
+class CoreDataStack {
+    static let shared = CoreDataStack()
+    lazy var container: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "Anywhere Reader")
+        container.loadPersistentStores { (_, error) in
+            if let error = error {
+                fatalError("Failed to load persistent store: \(error)")
+            }
+        }
+        
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        
+        return container
+    }()
+    
+    var mainContext: NSManagedObjectContext {
+        return container.viewContext
+    }
+    
+    static let moc = CoreDataStack.shared.mainContext
+}

--- a/ios/Anywhere Reader/Anywhere Reader/Model Controller/ArticleController.swift
+++ b/ios/Anywhere Reader/Anywhere Reader/Model Controller/ArticleController.swift
@@ -14,7 +14,7 @@ class ArticleController {
     var mockDataURL: URL {
         return Bundle.main.url(forResource: "example", withExtension: "json")!
     }
-    var articles: [Article] = []
+    var articles: [ArticleRep] = []
     
 //    func fetchArticles(for user: User, fetchArticlesComplete: @escaping (_ status: Bool, _ error: Error?) -> ()) {
 //
@@ -79,7 +79,7 @@ class ArticleController {
             guard let data = data else { return }
             
             do {
-                let article = try JSONDecoder().decode(Article.self, from: data)
+                let article = try JSONDecoder().decode(ArticleRep.self, from: data)
                 self.articles.append(article)
             } catch let decodeError {
                 NSLog("Error with decoding article")

--- a/ios/Anywhere Reader/Anywhere Reader/Model/ArticleRep.swift
+++ b/ios/Anywhere Reader/Anywhere Reader/Model/ArticleRep.swift
@@ -10,7 +10,7 @@ import Foundation
 
 typealias Articles = [ArticleRep]
 
-struct ArticleRep: Codable {
+struct ArticleRep: Codable, Equatable {
     let id: Int
     let title: String
     let author: String
@@ -36,4 +36,31 @@ struct ArticleRep: Codable {
         case tags = "tags"
         case text = "text"
     }
+}
+
+func == (lhs: ArticleRep, rhs: Article) -> Bool {
+    return
+        lhs.id == rhs.id &&
+            lhs.title == rhs.title &&
+            lhs.author == rhs.author &&
+            lhs.normalURL == rhs.normalURL &&
+            lhs.resolvedURL == rhs.resolvedURL &&
+            lhs.dateSaved == rhs.dateSaved &&
+            lhs.datePublished == rhs.datePublished &&
+            lhs.excerpt == rhs.excerpt &&
+            lhs.coverImage == rhs.coverImage &&
+            lhs.tags == rhs.tags &&
+            lhs.text == rhs.text
+}
+
+func == (lhs: Article, rhs: ArticleRep) -> Bool {
+    return rhs == lhs
+}
+
+func != (lhs: ArticleRep, rhs: Article) -> Bool {
+    return !(rhs == lhs)
+}
+
+func != (lhs: Article, rhs: ArticleRep) -> Bool {
+    return rhs != lhs
 }

--- a/ios/Anywhere Reader/Anywhere Reader/Model/ArticleRep.swift
+++ b/ios/Anywhere Reader/Anywhere Reader/Model/ArticleRep.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-typealias Articles = [Article]
+typealias Articles = [ArticleRep]
 
-struct Article: Codable {
+struct ArticleRep: Codable {
     let id: Int
     let title: String
     let author: String

--- a/ios/Anywhere Reader/Anywhere Reader/View Controller/Content Collection/Collection View Cells/DocumentCollectionViewCell.swift
+++ b/ios/Anywhere Reader/Anywhere Reader/View Controller/Content Collection/Collection View Cells/DocumentCollectionViewCell.swift
@@ -12,7 +12,7 @@ import Kingfisher
 class DocumentCollectionViewCell: UICollectionViewCell {
     
     // MARK: - Properties
-    var article: Article? {
+    var article: ArticleRep? {
         didSet {
             updateViews()
         }

--- a/ios/Anywhere Reader/Anywhere Reader/View Controller/Content Detail/ContentDetailViewController.swift
+++ b/ios/Anywhere Reader/Anywhere Reader/View Controller/Content Detail/ContentDetailViewController.swift
@@ -31,7 +31,7 @@ class ContentDetailViewController: UIViewController {
     
     // MARK: - Public properties
     
-    public var article: Article? {
+    public var article: ArticleRep? {
         didSet {
             updateViews()
         }


### PR DESCRIPTION
# Description

Renames Article struct to ArticleRep so CoreData entity can be named Article. Creates core data stack and Article entity as well as its properties. Implements all four functions required for Article and Article rep to be comparable to each other using == and !=. Adds an extension to Article entity so it conforms to Encodable protocol. Makes it easy to create an Article based off of an ArticleRep.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Change status

- [X] Complete, tested, ready to review and merge

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts