### PR TITLE
Django admin documentation generator

### DIFF
--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -22,6 +22,7 @@ requests = "*"
 "django-rest-framework-social-oauth2" = "*"
 django-oauth-toolkit = "*"
 python-social-auth = "*"
+docutils = "*"
 
 [dev-packages]
 

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c05fec0fbe4763be81bd4f1cabdfc51ad0af8586c5b18f153095a5bc990c5758"
+            "sha256": "712d740d772a5d995354427d84b438a5a3ad0a0b1b42e0ad6f9621ce5d92a82f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -120,6 +120,15 @@
             ],
             "index": "pypi",
             "version": "==3.9.0"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
+                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
+                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
+            ],
+            "index": "pypi",
+            "version": "==0.14"
         },
         "feedfinder2": {
             "hashes": [

--- a/backend/project/settings.py
+++ b/backend/project/settings.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
     'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
     'django.contrib.admin',
+    'django.contrib.admindocs',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -70,6 +71,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.contrib.admindocs.middleware.XViewMiddleware',
 ]
 
 ROOT_URLCONF = 'project.urls'

--- a/backend/project/urls.py
+++ b/backend/project/urls.py
@@ -27,6 +27,7 @@ from django.contrib.auth.models import User
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
+    path('admin/doc/', include('django.contrib.admindocs.urls')),
     path('admin/', admin.site.urls),
     path('auth/', include('auth.urls')),
     path('api/', include('api.urls'))


### PR DESCRIPTION
# Description

Enables the built-in Django document generator. When you log in to the admin panel, there is now a link in the upper-right for documentation, containing a myriad of auto-generated info about all the views, models, and such in our project.

Fixes # https://trello.com/c/6daHz70T/223-self-documenting-django

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Minimal setup via the documentation at https://docs.djangoproject.com/en/2.1/ref/contrib/admin/admindocs/. Logged in and verified I could browse each category, and picked a random entry from each for a cursory check that things worked as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
