### PR TITLE
FB AppID bugfix

### DIFF
--- a/frontend/src/components/FBAuth/FBAuth.js
+++ b/frontend/src/components/FBAuth/FBAuth.js
@@ -8,6 +8,7 @@ const FBClick = styled.span`
 
 class FBAuth extends Component {
 	state = {
+		// TODO: Set this in the userReducers state, then pass it down. This will make sure values are easy to locate going forward.
 		fbAppId:
 			process.env.NODE_ENV === 'production'
 				? '719662021765780'

--- a/frontend/src/components/FBAuth/FBAuth.js
+++ b/frontend/src/components/FBAuth/FBAuth.js
@@ -8,6 +8,10 @@ const FBClick = styled.span`
 
 class FBAuth extends Component {
 	state = {
+		fbAppId:
+			process.env.NODE_ENV === 'production'
+				? '719662021765780'
+				: '196409721290076',
 		error: ''
 	};
 
@@ -23,7 +27,7 @@ class FBAuth extends Component {
 
 	render() {
 		return (
-			<FacebookProvider appId="196409721290076">
+			<FacebookProvider appId={this.state.fbAppId}>
 				<Login
 					scope="email"
 					onResponse={this.handleResponse}


### PR DESCRIPTION
Sets the FB appID for the web frontend based on the value of process.env.NODE_ENV

# Description

The Facebook AppID had been hard-coded in the web client application to the testing ID, but needed to be dynamically set based on either being deployed to Netlify or localhost. This bugfix accomplishes this. 

Fixes # https://trello.com/c/Y8brihtH/238-fix-setting-facebook-appid-in-the-web-client

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

The set value is based on whether process.env.NODE_ENV is set to production. When tested on localhost, it falls over to the else value in the ternary operator, which is the test ID as expected. Was able to login.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
