### PR TITLE
Fixes share extension info.plist bug

### DIFF
--- a/ios/Anywhere Reader/Anywhere Reader Share Extension/Info.plist
+++ b/ios/Anywhere Reader/Anywhere Reader Share Extension/Info.plist
@@ -25,7 +25,10 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>NSExtensionActivationRule</key>
-			<string>TRUEPREDICATE</string>
+			<dict>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
 		</dict>
 		<key>NSExtensionMainStoryboard</key>
 		<string>MainInterface</string>


### PR DESCRIPTION
# Description

Adds web url as an NSExtensionAttribute in info.plist. This silences the warning and makes it so the extension is only an option in apps that have web urls.

Fixes: Share extension info.plist bug

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Change status

- [X] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [X] Ran on iPhone XR simulator

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts