### PR TITLE
iOS facebook auth bug

### DIFF
--- a/ios/Anywhere Reader/Anywhere Reader Share Extension/ShareViewController.swift
+++ b/ios/Anywhere Reader/Anywhere Reader Share Extension/ShareViewController.swift
@@ -9,36 +9,40 @@
 import UIKit
 import Social
 
-class ShareViewController: SLComposeServiceViewController {
-    let sharedURL = "sharedURL"
+class ShareViewController: UIViewController {
+    let sharedURLKey = "sharedURL"
     
-    override func isContentValid() -> Bool {
-        // Do validation of contentText and/or NSExtensionContext attachments here
-        return true
+    @IBOutlet weak var mainView: UIView!
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        let alert = UIAlertController(title: nil, message: "Save this webpage to be viewed offline on Anywhere Reader?", preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: "Cancel", style: .default) { _ in
+            self.extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
+        }
+        let saveAction = UIAlertAction(title: "Save", style: .default) { _ in
+            self.saveWebPageToUserDefaults()
+        }
+        alert.addAction(cancelAction)
+        alert.addAction(saveAction)
+        
+        self.present(alert, animated: true, completion: nil)
     }
-
-    override func didSelectPost() {
-        if let item = extensionContext?.inputItems.first as? NSExtensionItem {
-            if let itemProvider = item.attachments?.first {
-                if itemProvider.hasItemConformingToTypeIdentifier("public.url") {
-                    itemProvider.loadItem(forTypeIdentifier: "public.url", options: nil, completionHandler: { (url, error) -> Void in
-                        if let shareURL = url as? NSURL {
-                            if let shareURLAsString = shareURL.absoluteString {
-                                let sharedUserDefaults = UserDefaults(suiteName: "group.com.lambdaschool.AnywhereReader")
-                                sharedUserDefaults?.set(shareURLAsString, forKey: self.sharedURL)
-                                sharedUserDefaults?.synchronize()
-                            }
-                        }
-                        self.extensionContext?.completeRequest(returningItems: [], completionHandler:nil)
-                    })
+    
+    func saveWebPageToUserDefaults() {
+        
+        if let item = extensionContext?.inputItems.first as? NSExtensionItem,
+            let itemProvider = item.attachments?.first,
+            itemProvider.hasItemConformingToTypeIdentifier("public.url") {
+            
+            itemProvider.loadItem(forTypeIdentifier: "public.url", options: nil) { url, error in
+                if let shareURL = url as? NSURL, let shareURLAsString = shareURL.absoluteString {
+                    let sharedUserDefaults = UserDefaults(suiteName: "group.com.lambdaschool.AnywhereReader")
+                    sharedUserDefaults?.set(shareURLAsString, forKey: self.sharedURLKey)
                 }
+                self.extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
             }
         }
     }
-
-    override func configurationItems() -> [Any]! {
-        // To add configuration options via table cells at the bottom of the sheet, return an array of SLComposeSheetConfigurationItem here.
-        return []
-    }
-
 }

--- a/ios/Anywhere Reader/Podfile
+++ b/ios/Anywhere Reader/Podfile
@@ -7,6 +7,7 @@ target 'Anywhere Reader' do
 
   # Pods for Anywhere Reader
   pod 'Kingfisher', '~> 5.0'
-  pod 'FacebookCore'
   pod 'FacebookLogin'
+  pod 'FBSDKCoreKit', '4.38.1'
+  pod 'FBSDKLoginKit', '4.38.1'
 end

--- a/ios/Anywhere Reader/Podfile.lock
+++ b/ios/Anywhere Reader/Podfile.lock
@@ -13,15 +13,16 @@ PODS:
     - FacebookCore (~> 0.5)
     - FBSDKCoreKit (~> 4.37)
     - FBSDKLoginKit (~> 4.37)
-  - FBSDKCoreKit (4.39.0):
+  - FBSDKCoreKit (4.38.1):
     - Bolts (~> 1.9)
-  - FBSDKLoginKit (4.39.0):
+  - FBSDKLoginKit (4.38.1):
     - FBSDKCoreKit
   - Kingfisher (5.0.0)
 
 DEPENDENCIES:
-  - FacebookCore
   - FacebookLogin
+  - FBSDKCoreKit (= 4.38.1)
+  - FBSDKLoginKit (= 4.38.1)
   - Kingfisher (~> 5.0)
 
 SPEC REPOS:
@@ -37,10 +38,10 @@ SPEC CHECKSUMS:
   Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
   FacebookCore: 74288d0add931d361b1596beae787ab72c438249
   FacebookLogin: ebcf34714a1cb9f0759d9f071cfb01ed500996cf
-  FBSDKCoreKit: 1e3981faefab8c88edfaa9eecd94aab02d99a9bc
-  FBSDKLoginKit: 30ba5039a2c53d65a75103889bc2deebdacd5a1f
+  FBSDKCoreKit: 8d47857400e2f5bdea697a80daff882e91c84ef6
+  FBSDKLoginKit: 4621c690d9dd8628031a4791497062183ea34b0d
   Kingfisher: 2b0dd651e4fe5a07305b8242fde56f8e2d410f58
 
-PODFILE CHECKSUM: 47ca0feaa04b8ac70125dd14b4c4cdd372655650
+PODFILE CHECKSUM: 9f65762b5bf7f93335f0986cde03d3be8fbd2c1f
 
 COCOAPODS: 1.5.3

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAccessToken.h
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAccessToken.h
@@ -58,10 +58,7 @@ FOUNDATION_EXPORT NSString *const FBSDKAccessTokenDidChangeNotification;
   of an access token, this key will also exist since the access token
   is moving from a null state (no user) to a non-null state (user).
  */
-FOUNDATION_EXPORT NSString *const FBSDKAccessTokenDidChangeUserIDKey;
-
-FOUNDATION_EXPORT NSString *const FBSDKAccessTokenDidChangeUserID
-DEPRECATED_MSG_ATTRIBUTE("Renamed `FBSDKAccessTokenDidChangeUserIDKey`");
+FOUNDATION_EXPORT NSString *const FBSDKAccessTokenDidChangeUserID;
 
 /*
   key in notification's userInfo object for getting the old token.
@@ -81,10 +78,7 @@ FOUNDATION_EXPORT NSString *const FBSDKAccessTokenChangeNewKey;
  A key in the notification's userInfo that will be set
  if and only if the token has expired.
  */
-FOUNDATION_EXPORT NSString *const FBSDKAccessTokenDidExpireKey;
-
-FOUNDATION_EXPORT NSString *const FBSDKAccessTokenDidExpire
-DEPRECATED_MSG_ATTRIBUTE("Renamed `FBSDKAccessTokenDidExpireKey`");
+FOUNDATION_EXPORT NSString *const FBSDKAccessTokenDidExpire;
 
 
 /**

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAccessToken.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAccessToken.m
@@ -33,11 +33,9 @@ NSString *const FBSDKAccessTokenDidChangeNotification = @"com.facebook.sdk.FBSDK
 
 #endif
 
-NSString *const FBSDKAccessTokenDidChangeUserIDKey = @"FBSDKAccessTokenDidChangeUserID";
 NSString *const FBSDKAccessTokenDidChangeUserID = @"FBSDKAccessTokenDidChangeUserID";
 NSString *const FBSDKAccessTokenChangeNewKey = @"FBSDKAccessToken";
 NSString *const FBSDKAccessTokenChangeOldKey = @"FBSDKAccessTokenOld";
-NSString *const FBSDKAccessTokenDidExpireKey = @"FBSDKAccessTokenDidExpire";
 NSString *const FBSDKAccessTokenDidExpire = @"FBSDKAccessTokenDidExpire";
 
 static FBSDKAccessToken *g_currentAccessToken;
@@ -123,7 +121,7 @@ static FBSDKAccessToken *g_currentAccessToken;
     [FBSDKInternalUtility dictionary:userInfo setObject:g_currentAccessToken forKey:FBSDKAccessTokenChangeOldKey];
     // We set this flag also when the current Access Token was not valid, since there might be legacy code relying on it
     if (![g_currentAccessToken.userID isEqualToString:token.userID] || ![self currentAccessTokenIsActive]) {
-      userInfo[FBSDKAccessTokenDidChangeUserIDKey] = @YES;
+      userInfo[FBSDKAccessTokenDidChangeUserID] = @YES;
     }
 
     g_currentAccessToken = token;
@@ -134,7 +132,7 @@ static FBSDKAccessToken *g_currentAccessToken;
       [FBSDKInternalUtility deleteFacebookCookies];
     }
 
-    [FBSDKSettings accessTokenCache].accessToken = token;
+    [[FBSDKSettings accessTokenCache] cacheAccessToken:token];
     [[NSNotificationCenter defaultCenter] postNotificationName:FBSDKAccessTokenDidChangeNotification
                                                         object:[self class]
                                                       userInfo:userInfo];
@@ -165,14 +163,14 @@ static FBSDKAccessToken *g_currentAccessToken;
 - (NSUInteger)hash
 {
   NSUInteger subhashes[] = {
-    self.tokenString.hash,
-    self.permissions.hash,
-    self.declinedPermissions.hash,
-    self.appID.hash,
-    self.userID.hash,
-    self.refreshDate.hash,
-    self.expirationDate.hash,
-    self.dataAccessExpirationDate.hash
+    [self.tokenString hash],
+    [self.permissions hash],
+    [self.declinedPermissions hash],
+    [self.appID hash],
+    [self.userID hash],
+    [self.refreshDate hash],
+    [self.expirationDate hash],
+    [self.dataAccessExpirationDate hash]
   };
   return [FBSDKMath hashWithIntegerArray:subhashes count:sizeof(subhashes) / sizeof(subhashes[0])];
 }
@@ -216,7 +214,7 @@ static FBSDKAccessToken *g_currentAccessToken;
   return YES;
 }
 
-- (instancetype)initWithCoder:(NSCoder *)decoder
+- (id)initWithCoder:(NSCoder *)decoder
 {
   NSString *appID = [decoder decodeObjectOfClass:[NSString class] forKey:FBSDK_ACCESSTOKEN_APPID_KEY];
   NSSet *declinedPermissions = [decoder decodeObjectOfClass:[NSSet class] forKey:FBSDK_ACCESSTOKEN_DECLINEDPERMISSIONS_KEY];
@@ -228,8 +226,8 @@ static FBSDKAccessToken *g_currentAccessToken;
   NSDate *dataAccessExpirationDate = [decoder decodeObjectOfClass:[NSDate class] forKey:FBSDK_ACCESSTOKEN_DATA_EXPIRATIONDATE_KEY];
 
   return [self initWithTokenString:tokenString
-                       permissions:permissions.allObjects
-               declinedPermissions:declinedPermissions.allObjects
+                       permissions:[permissions allObjects]
+               declinedPermissions:[declinedPermissions allObjects]
                              appID:appID
                             userID:userID
                     expirationDate:expirationDate

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppEvents.h
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppEvents.h
@@ -160,7 +160,7 @@ FOUNDATION_EXPORT NSString *const FBSDKAppEventNameSchedule;
 /** The start of a free trial of a product or service you offer (example: trial subscription). */
 FOUNDATION_EXPORT NSString *const FBSDKAppEventNameStartTrial;
 
-/** The submission of an application for a product, service or program you offer (example: credit card, educational program or job). */
+/** The submission of an application for a product, service or program you offer (example: credit card, educational program or job).. */
 FOUNDATION_EXPORT NSString *const FBSDKAppEventNameSubmitApplication;
 
 /** The start of a paid subscription for a product or service you offer. */
@@ -217,70 +217,6 @@ FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterNameSearchString;
 
 /** Parameter key used to specify whether the activity being logged about was successful or not.  `FBSDKAppEventParameterValueYes` and `FBSDKAppEventParameterValueNo` are good canonical values to use for this parameter. */
 FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterNameSuccess;
-
-/**
- @methodgroup Predefined event name parameters for common additional information to accompany events logged through the `logProductItem` method on `FBSDKAppEvents`.
- */
-
-/** Parameter key used to specify the product item's custom label 0. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductCustomLabel0;
-
-/** Parameter key used to specify the product item's custom label 1. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductCustomLabel1;
-
-/** Parameter key used to specify the product item's custom label 2. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductCustomLabel2;
-
-/** Parameter key used to specify the product item's custom label 3. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductCustomLabel3;
-
-/** Parameter key used to specify the product item's custom label 4. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductCustomLabel4;
-
-/** Parameter key used to specify the product item's AppLink app URL for iOS. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductAppLinkIOSUrl;
-
-/** Parameter key used to specify the product item's AppLink app ID for iOS App Store. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductAppLinkIOSAppStoreID;
-
-/** Parameter key used to specify the product item's AppLink app name for iOS. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductAppLinkIOSAppName;
-
-/** Parameter key used to specify the product item's AppLink app URL for iPhone. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductAppLinkIPhoneUrl;
-
-/** Parameter key used to specify the product item's AppLink app ID for iPhone App Store. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductAppLinkIPhoneAppStoreID;
-
-/** Parameter key used to specify the product item's AppLink app name for iPhone. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductAppLinkIPhoneAppName;
-
-/** Parameter key used to specify the product item's AppLink app URL for iPad. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductAppLinkIPadUrl;
-
-/** Parameter key used to specify the product item's AppLink app ID for iPad App Store. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductAppLinkIPadAppStoreID;
-
-/** Parameter key used to specify the product item's AppLink app name for iPad. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductAppLinkIPadAppName;
-
-/** Parameter key used to specify the product item's AppLink app URL for Android. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductAppLinkAndroidUrl;
-
-/** Parameter key used to specify the product item's AppLink fully-qualified package name for intent generation. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductAppLinkAndroidPackage;
-
-/** Parameter key used to specify the product item's AppLink app name for Android. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductAppLinkAndroidAppName;
-
-/** Parameter key used to specify the product item's AppLink app URL for Windows Phone. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductAppLinkWindowsPhoneUrl;
-
-/** Parameter key used to specify the product item's AppLink app ID, as a GUID, for App Store. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductAppLinkWindowsPhoneAppID;
-
-/** Parameter key used to specify the product item's AppLink app name for Windows Phone. */
-FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterProductAppLinkWindowsPhoneAppName;
 
 /*
  @methodgroup Predefined values to assign to event parameters that accompany events logged through the `logEvent` family
@@ -614,17 +550,6 @@ FOUNDATION_EXPORT NSString *const FBSDKAppEventParameterNameOrderID;
  @param deviceToken Device token data.
  */
 + (void)setPushNotificationsDeviceToken:(NSData *)deviceToken;
-
-/**
- Sets and sends device token string to register the current application for push notifications.
-
-
-
- Sets and sends a device token string
-
- @param deviceTokenString Device token string.
- */
-+ (void)setPushNotificationsDeviceTokenString:(NSString *)deviceTokenString;
 
 /*
  * Control over event batching/flushing

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppEvents.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppEvents.m
@@ -363,7 +363,6 @@ static NSString *g_overrideAppID = nil;
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     _userID = [defaults stringForKey:USER_ID_USER_DEFAULTS_KEY];
-    [self fetchServerConfiguration:nil];
   }
 
   return self;
@@ -425,7 +424,7 @@ static NSString *g_overrideAppID = nil;
       parameters:(NSDictionary *)parameters
 {
   [FBSDKAppEvents logEvent:eventName
-                valueToSum:@(valueToSum)
+                valueToSum:[NSNumber numberWithDouble:valueToSum]
                 parameters:parameters
                accessToken:nil];
 }
@@ -477,7 +476,7 @@ static NSString *g_overrideAppID = nil;
   }
 
   [FBSDKAppEvents logEvent:FBSDKAppEventNamePurchased
-                valueToSum:@(purchaseAmount)
+                valueToSum:[NSNumber numberWithDouble:purchaseAmount]
                 parameters:newParameters
                accessToken:accessToken];
 
@@ -568,7 +567,7 @@ static NSString *g_overrideAppID = nil;
     [dict setValuesForKeysWithDictionary:parameters];
   }
 
-  dict[FBSDKAppEventParameterProductItemID] = itemID;
+  [dict setObject:itemID forKey:FBSDKAppEventParameterProductItemID];
 
   NSString *avail = nil;
   switch (availability) {
@@ -584,7 +583,7 @@ static NSString *g_overrideAppID = nil;
       avail = @"DISCONTINUED"; break;
   }
   if (avail) {
-    dict[FBSDKAppEventParameterProductAvailability] = avail;
+    [dict setObject:avail forKey:FBSDKAppEventParameterProductAvailability];
   }
 
   NSString *cond = nil;
@@ -597,23 +596,23 @@ static NSString *g_overrideAppID = nil;
       cond = @"USED"; break;
   }
   if (cond) {
-    dict[FBSDKAppEventParameterProductCondition] = cond;
+    [dict setObject:cond forKey:FBSDKAppEventParameterProductCondition];
   }
 
-  dict[FBSDKAppEventParameterProductDescription] = description;
-  dict[FBSDKAppEventParameterProductImageLink] = imageLink;
-  dict[FBSDKAppEventParameterProductLink] = link;
-  dict[FBSDKAppEventParameterProductTitle] = title;
-  dict[FBSDKAppEventParameterProductPriceAmount] = [NSString stringWithFormat:@"%.3lf", priceAmount];
-  dict[FBSDKAppEventParameterProductPriceCurrency] = currency;
+  [dict setObject:description forKey:FBSDKAppEventParameterProductDescription];
+  [dict setObject:imageLink forKey:FBSDKAppEventParameterProductImageLink];
+  [dict setObject:link forKey:FBSDKAppEventParameterProductLink];
+  [dict setObject:title forKey:FBSDKAppEventParameterProductTitle];
+  [dict setObject:[NSString stringWithFormat:@"%.3lf", priceAmount] forKey:FBSDKAppEventParameterProductPriceAmount];
+  [dict setObject:currency forKey:FBSDKAppEventParameterProductPriceCurrency];
   if (gtin) {
-    dict[FBSDKAppEventParameterProductGTIN] = gtin;
+    [dict setObject:gtin forKey:FBSDKAppEventParameterProductGTIN];
   }
   if (mpn) {
-    dict[FBSDKAppEventParameterProductMPN] = mpn;
+    [dict setObject:mpn forKey:FBSDKAppEventParameterProductMPN];
   }
   if (brand) {
-    dict[FBSDKAppEventParameterProductBrand] = brand;
+    [dict setObject:brand forKey:FBSDKAppEventParameterProductBrand];
   }
 
   [FBSDKAppEvents logEvent:FBSDKAppEventNameProductCatalogUpdate
@@ -640,11 +639,6 @@ static NSString *g_overrideAppID = nil;
 + (void)setPushNotificationsDeviceToken:(NSData *)deviceToken
 {
   NSString *deviceTokenString = [FBSDKInternalUtility hexadecimalStringFromData:deviceToken];
-  [FBSDKAppEvents setPushNotificationsDeviceTokenString:deviceTokenString];
-}
-
-+ (void)setPushNotificationsDeviceTokenString:(NSString *)deviceTokenString
-{
   if (deviceTokenString == nil) {
     [FBSDKAppEvents singleton].pushNotificationsDeviceTokenString = nil;
     return;
@@ -862,10 +856,7 @@ static NSString *g_overrideAppID = nil;
 + (void)sendEventBindingsToUnity
 {
   // Send event bindings to Unity only Unity is initialized
-  if ([FBSDKAppEvents singleton]->_isUnityInit
-      && [FBSDKAppEvents singleton]->_serverConfiguration
-      && [NSJSONSerialization isValidJSONObject:[FBSDKAppEvents singleton]->_serverConfiguration.eventBindings]
-      ) {
+  if ([FBSDKAppEvents singleton]->_isUnityInit) {
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:[FBSDKAppEvents singleton]->_serverConfiguration.eventBindings ?: @""
                                                        options:0
                                                          error:nil];
@@ -931,7 +922,7 @@ static NSString *g_overrideAppID = nil;
 - (void)publishInstall
 {
   NSString *appID = [self appID];
-  if (appID.length == 0) {
+  if ([appID length] == 0) {
     [FBSDKLogger singleShotLogEntry:FBSDKLoggingBehaviorDeveloperErrors logEntry:@"Missing [FBSDKAppEvents appID] for [FBSDKAppEvents publishInstall:]"];
     return;
   }
@@ -1144,7 +1135,7 @@ static NSString *g_overrideAppID = nil;
     return;
   }
 
-  if (appEventsState.appID.length == 0) {
+  if ([appEventsState.appID length] == 0) {
     [FBSDKLogger singleShotLogEntry:FBSDKLoggingBehaviorDeveloperErrors logEntry:@"Missing [FBSDKAppEvents appEventsState.appID] for [FBSDKAppEvents flushOnMainQueue:]"];
     return;
   }
@@ -1163,7 +1154,7 @@ static NSString *g_overrideAppID = nil;
                                            activityParametersDictionaryForEvent:@"CUSTOM_APP_EVENTS"
                                            implicitEventsOnly:appEventsState.areAllEventsImplicit
                                            shouldAccessAdvertisingID:self->_serverConfiguration.advertisingIDEnabled];
-    NSInteger length = receipt_data.length;
+    NSInteger length = [receipt_data length];
     if (length > 0) {
       postParameters[@"receipt_data"] = receipt_data;
     }
@@ -1261,7 +1252,7 @@ static NSString *g_overrideAppID = nil;
       break;
 
     case FlushResultServerError:
-      resultString = [NSString stringWithFormat:@"Server Error - %@", error.description];
+      resultString = [NSString stringWithFormat:@"Server Error - %@", [error description]];
       break;
   }
 

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkNavigation.h
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkNavigation.h
@@ -69,12 +69,6 @@ NS_EXTENSION_UNAVAILABLE_IOS("Not available in app extension")
 /*! The AppLink to navigate to */
 @property (nonatomic, strong, readonly) FBSDKAppLink *appLink;
 
-/*!
- Return navigation type for current instance.
- No-side-effect version of navigate:
- */
-@property (nonatomic, readonly) FBSDKAppLinkNavigationType navigationType;
-
 /*! Creates an AppLinkNavigation with the given link, extras, and App Link data */
 + (instancetype)navigationWithAppLink:(FBSDKAppLink *)appLink
                                extras:(NSDictionary<NSString *, id> *)extras
@@ -108,6 +102,12 @@ NS_EXTENSION_UNAVAILABLE_IOS("Not available in app extension")
  internal web view instead of going straight to the browser for regular links.)
  */
 + (FBSDKAppLinkNavigationType)navigationTypeForLink:(FBSDKAppLink *)link;
+
+/*!
+ Return navigation type for current instance.
+ No-side-effect version of navigate:
+ */
+- (FBSDKAppLinkNavigationType)navigationType;
 
 /*! Navigates to a URL (an asynchronous action) and returns a FBSDKNavigationType */
 + (void)navigateToURL:(NSURL *)destination handler:(FBSDKAppLinkNavigationHandler)handler;

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkNavigation.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkNavigation.m
@@ -88,7 +88,7 @@ static id<FBSDKAppLinkResolving> defaultResolver;
         NSString *encoded = [self stringByEscapingQueryString:jsonString];
 
         NSString *endUrlString = [NSString stringWithFormat:@"%@%@%@=%@",
-                                  targetUrl.absoluteString,
+                                  [targetUrl absoluteString],
                                   targetUrl.query ? @"&" : @"?",
                                   FBSDKAppLinkDataParameterName,
                                   encoded];
@@ -150,8 +150,8 @@ static id<FBSDKAppLinkResolving> defaultResolver;
     NSMutableDictionary<NSString *, id> *logData =
     [[NSMutableDictionary alloc] init];
 
-    NSString *outputURLScheme = outputURL.scheme;
-    NSString *outputURLString = outputURL.absoluteString;
+    NSString *outputURLScheme = [outputURL scheme];
+    NSString *outputURLString = [outputURL absoluteString];
     if (outputURLScheme) {
         logData[@"outputURLScheme"] = outputURLScheme;
     }
@@ -159,9 +159,9 @@ static id<FBSDKAppLinkResolving> defaultResolver;
         logData[@"outputURL"] = outputURLString;
     }
 
-    NSString *sourceURLString = self.appLink.sourceURL.absoluteString;
-    NSString *sourceURLHost = self.appLink.sourceURL.host;
-    NSString *sourceURLScheme = self.appLink.sourceURL.scheme;
+    NSString *sourceURLString = [self.appLink.sourceURL absoluteString];
+    NSString *sourceURLHost = [self.appLink.sourceURL host];
+    NSString *sourceURLScheme = [self.appLink.sourceURL scheme];
     if (sourceURLString) {
         logData[@"sourceURL"] = sourceURLString;
     }
@@ -171,8 +171,8 @@ static id<FBSDKAppLinkResolving> defaultResolver;
     if (sourceURLScheme) {
         logData[@"sourceScheme"] = sourceURLScheme;
     }
-    if (error.localizedDescription) {
-        logData[@"error"] = error.localizedDescription;
+    if ([error localizedDescription]) {
+        logData[@"error"] = [error localizedDescription];
     }
     NSString *success = nil; //no
     NSString *linkType = nil; // unknown;
@@ -199,7 +199,7 @@ static id<FBSDKAppLinkResolving> defaultResolver;
         logData[@"type"] = linkType;
     }
 
-    if (self.appLink.backToReferrer) {
+    if ([self.appLink isBackToReferrer]) {
         [FBSDKMeasurementEvent postNotificationForEventName:FBSDKAppLinkNavigateBackToReferrerEventName args:logData];
     } else {
         [FBSDKMeasurementEvent postNotificationForEventName:FBSDKAppLinkNavigateOutEventName args:logData];

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkResolver.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkResolver.m
@@ -145,25 +145,25 @@ static Class g_BFTaskClass;
       return;
     }
     for (NSURL *url in toFind) {
-      id nestedObject = result[url.absoluteString][kAppLinksKey];
+      id nestedObject = [[result objectForKey:url.absoluteString] objectForKey:kAppLinksKey];
       NSMutableArray *rawTargets = [NSMutableArray array];
       if (idiomSpecificField) {
-        [rawTargets addObjectsFromArray:nestedObject[idiomSpecificField]];
+        [rawTargets addObjectsFromArray:[nestedObject objectForKey:idiomSpecificField]];
       }
-      [rawTargets addObjectsFromArray:nestedObject[kIOSKey]];
+      [rawTargets addObjectsFromArray:[nestedObject objectForKey:kIOSKey]];
 
       NSMutableArray<FBSDKAppLinkTarget *> *targets = [NSMutableArray arrayWithCapacity:rawTargets.count];
       for (id rawTarget in rawTargets) {
-        [targets addObject:[FBSDKAppLinkTarget appLinkTargetWithURL:[NSURL URLWithString:rawTarget[kURLKey]]
-                                                         appStoreId:rawTarget[kIOSAppStoreIdKey]
-                                                            appName:rawTarget[kIOSAppNameKey]]];
+        [targets addObject:[FBSDKAppLinkTarget appLinkTargetWithURL:[NSURL URLWithString:[rawTarget objectForKey:kURLKey]]
+                                                         appStoreId:[rawTarget objectForKey:kIOSAppStoreIdKey]
+                                                            appName:[rawTarget objectForKey:kIOSAppNameKey]]];
       }
 
-      id webTarget = nestedObject[kWebKey];
-      NSString *webFallbackString = webTarget[kURLKey];
+      id webTarget = [nestedObject objectForKey:kWebKey];
+      NSString *webFallbackString = [webTarget objectForKey:kURLKey];
       NSURL *fallbackUrl = webFallbackString ? [NSURL URLWithString:webFallbackString] : url;
 
-      NSNumber *shouldFallback = webTarget[kShouldFallbackKey];
+      NSNumber *shouldFallback = [webTarget objectForKey:kShouldFallbackKey];
       if (shouldFallback && !shouldFallback.boolValue) {
         fallbackUrl = nil;
       }
@@ -236,25 +236,25 @@ static Class g_BFTaskClass;
       return;
     }
     for (NSURL *url in toFind) {
-      id nestedObject = result[url.absoluteString][kAppLinksKey];
+      id nestedObject = [[result objectForKey:url.absoluteString] objectForKey:kAppLinksKey];
       NSMutableArray *rawTargets = [NSMutableArray array];
       if (idiomSpecificField) {
-        [rawTargets addObjectsFromArray:nestedObject[idiomSpecificField]];
+        [rawTargets addObjectsFromArray:[nestedObject objectForKey:idiomSpecificField]];
       }
-      [rawTargets addObjectsFromArray:nestedObject[kIOSKey]];
+      [rawTargets addObjectsFromArray:[nestedObject objectForKey:kIOSKey]];
 
       NSMutableArray<BFAppLinkTarget *> *targets = [NSMutableArray arrayWithCapacity:rawTargets.count];
       for (id rawTarget in rawTargets) {
-        [targets addObject:[g_BFAppLinkTargetClass appLinkTargetWithURL:[NSURL URLWithString:rawTarget[kURLKey]]
-                                                             appStoreId:rawTarget[kIOSAppStoreIdKey]
-                                                                appName:rawTarget[kIOSAppNameKey]]];
+        [targets addObject:[g_BFAppLinkTargetClass appLinkTargetWithURL:[NSURL URLWithString:[rawTarget objectForKey:kURLKey]]
+                                                             appStoreId:[rawTarget objectForKey:kIOSAppStoreIdKey]
+                                                                appName:[rawTarget objectForKey:kIOSAppNameKey]]];
       }
 
-      id webTarget = nestedObject[kWebKey];
-      NSString *webFallbackString = webTarget[kURLKey];
+      id webTarget = [nestedObject objectForKey:kWebKey];
+      NSString *webFallbackString = [webTarget objectForKey:kURLKey];
       NSURL *fallbackUrl = webFallbackString ? [NSURL URLWithString:webFallbackString] : url;
 
-      NSNumber *shouldFallback = webTarget[kShouldFallbackKey];
+      NSNumber *shouldFallback = [webTarget objectForKey:kShouldFallbackKey];
       if (shouldFallback && !shouldFallback.boolValue) {
         fallbackUrl = nil;
       }
@@ -284,7 +284,7 @@ static Class g_BFTaskClass;
 }
 #pragma clang diagnostic pop
 
-+ (instancetype)resolver
++ (id)resolver
 {
   return [[self alloc] initWithUserInterfaceIdiom:UI_USER_INTERFACE_IDIOM()];
 }

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkReturnToRefererController.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkReturnToRefererController.m
@@ -130,7 +130,7 @@ static const CFTimeInterval kFBSDKViewAnimationDuration = 0.25f;
 #pragma mark - Private
 
 - (void)statusBarFrameWillChange:(NSNotification *)notification {
-    NSValue *rectValue = [notification.userInfo valueForKey:UIApplicationStatusBarFrameUserInfoKey];
+    NSValue *rectValue = [[notification userInfo] valueForKey:UIApplicationStatusBarFrameUserInfoKey];
     CGRect newFrame;
     [rectValue getValue:&newFrame];
 
@@ -145,7 +145,7 @@ static const CFTimeInterval kFBSDKViewAnimationDuration = 0.25f;
 }
 
 - (void)statusBarFrameDidChange:(NSNotification *)notification {
-    NSValue *rectValue = [notification.userInfo valueForKey:UIApplicationStatusBarFrameUserInfoKey];
+    NSValue *rectValue = [[notification userInfo] valueForKey:UIApplicationStatusBarFrameUserInfoKey];
     CGRect newFrame;
     [rectValue getValue:&newFrame];
 

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkReturnToRefererView.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkReturnToRefererView.m
@@ -152,7 +152,7 @@ static const CGFloat FBSDKCloseButtonHeight = 12.0;
             include = YES;
             break;
         case FBSDKIncludeStatusBarInSizeIOS7AndLater: {
-            float systemVersion = [UIDevice currentDevice].systemVersion.floatValue;
+            float systemVersion = [[[UIDevice currentDevice] systemVersion] floatValue];
             include = (systemVersion >= 7.0);
             break;
         }
@@ -205,7 +205,7 @@ static const CGFloat FBSDKCloseButtonHeight = 12.0;
 #pragma mark - Private
 
 - (void)updateLabelText {
-    NSString *appName = (_refererAppLink && _refererAppLink.targets[0]) ? _refererAppLink.targets[0].appName : nil;
+    NSString *appName = (_refererAppLink && _refererAppLink.targets[0]) ? [_refererAppLink.targets[0] appName] : nil;
     _labelView.text = [self localizedLabelForReferer:appName];
 }
 
@@ -222,8 +222,8 @@ static const CGFloat FBSDKCloseButtonHeight = 12.0;
 
     CGContextRef context = UIGraphicsGetCurrentContext();
 
-    CGContextSetStrokeColorWithColor(context, color.CGColor);
-    CGContextSetFillColorWithColor(context, color.CGColor);
+    CGContextSetStrokeColorWithColor(context, [color CGColor]);
+    CGContextSetFillColorWithColor(context, [color CGColor]);
 
     CGContextSetLineWidth(context, 1.25f);
 
@@ -265,7 +265,7 @@ static const CGFloat FBSDKCloseButtonHeight = 12.0;
 }
 
 - (void)updateHidden {
-    super.hidden = _explicitlyHidden || _closed || !self.hasRefererData;
+    [super setHidden:_explicitlyHidden || _closed || !self.hasRefererData];
 }
 
 @end

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkUtility.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppLinkUtility.m
@@ -63,10 +63,10 @@ static NSString *const FBSDKDeferredAppLinkEvent = @"DEFERRED_APP_LINK";
         NSString *createTimeUtc = result[@"click_time"];
         if (createTimeUtc) {
           // append/translate the create_time_utc so it can be used by clients
-          NSString *modifiedURLString = [applinkURL.absoluteString
+          NSString *modifiedURLString = [[applinkURL absoluteString]
                                          stringByAppendingFormat:@"%@fb_click_time_utc=%@",
-                                         (applinkURL.query) ? @"&" : @"?" ,
-                                         createTimeUtc];
+                                         ([applinkURL query]) ? @"&" : @"?" ,
+                                         createTimeUtc ];
           applinkURL = [NSURL URLWithString:modifiedURLString];
         }
       }
@@ -88,12 +88,12 @@ static NSString *const FBSDKDeferredAppLinkEvent = @"DEFERRED_APP_LINK";
 + (NSString*)appInvitePromotionCodeFromURL:(NSURL*)url;
 {
   BFURL *parsedUrl = [[FBSDKInternalUtility resolveBoltsClassWithName:@"BFURL"] URLWithURL:url];
-  NSDictionary *extras = parsedUrl.appLinkExtras;
+  NSDictionary *extras = [parsedUrl appLinkExtras];
   if (extras) {
     NSString *deeplinkContextString = extras[@"deeplink_context"];
 
     // Parse deeplinkContext and extract promo code
-    if (deeplinkContextString.length > 0) {
+    if ([deeplinkContextString length] > 0) {
       NSError *error = nil;
       NSDictionary *deeplinkContextData = [FBSDKInternalUtility objectForJSONString:deeplinkContextString error:&error];
       if (!error && [deeplinkContextData isKindOfClass:[NSDictionary class]]) {

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
@@ -220,14 +220,14 @@ static NSString *const FBSDKAppLinkInboundEvent = @"fb_al_inbound";
   }
 
   _isAppLaunched = YES;
-  FBSDKAccessToken *cachedToken = [FBSDKSettings accessTokenCache].accessToken;
+  FBSDKAccessToken *cachedToken = [[FBSDKSettings accessTokenCache] fetchAccessToken];
   [FBSDKAccessToken setCurrentAccessToken:cachedToken];
   // fetch app settings
   [FBSDKServerConfigurationManager loadServerConfigurationWithCompletionBlock:NULL];
   // fetch gate keepers
   [FBSDKGateKeeperManager loadGateKeepers];
 
-  if ([FBSDKSettings autoLogAppEventsEnabled].boolValue) {
+  if ([[FBSDKSettings autoLogAppEventsEnabled] boolValue]) {
     [self _logSDKInitialize];
   }
 #if !TARGET_OS_TV
@@ -263,7 +263,7 @@ static NSString *const FBSDKAppLinkInboundEvent = @"fb_al_inbound";
 - (void)applicationDidBecomeActive:(NSNotification *)notification
 {
   // Auto log basic events in case autoLogAppEventsEnabled is set
-  if ([FBSDKSettings autoLogAppEventsEnabled].boolValue) {
+  if ([[FBSDKSettings autoLogAppEventsEnabled] boolValue]) {
     [FBSDKAppEvents activateApp];
   }
   //  _expectingBackground can be YES if the caller started doing work (like login)
@@ -281,7 +281,7 @@ static NSString *const FBSDKAppLinkInboundEvent = @"fb_al_inbound";
   if (notExpectingBackground) {
     _active = YES;
 #if !TARGET_OS_TV
-    [_pendingURLOpen applicationDidBecomeActive:notification.object];
+    [_pendingURLOpen applicationDidBecomeActive:[notification object]];
     [self _cancelBridgeRequest];
 #endif
     [[NSNotificationCenter defaultCenter] postNotificationName:FBSDKApplicationDidBecomeActiveNotification object:self];
@@ -425,7 +425,7 @@ static NSString *const FBSDKAppLinkInboundEvent = @"fb_al_inbound";
 
     NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
     NSURLQueryItem *sfvcQueryItem = [[NSURLQueryItem alloc] initWithName:@"sfvc" value:@"1"];
-    components.queryItems = [components.queryItems arrayByAddingObject:sfvcQueryItem];
+    [components setQueryItems:[components.queryItems arrayByAddingObject:sfvcQueryItem]];
     url = components.URL;
     FBSDKContainerViewController *container = [[FBSDKContainerViewController alloc] init];
     container.delegate = self;
@@ -515,8 +515,8 @@ static NSString *const FBSDKAppLinkInboundEvent = @"fb_al_inbound";
   NSURL *targetURL = [targetURLString isKindOfClass:[NSString class]] ? [NSURL URLWithString:targetURLString] : nil;
 
   NSMutableDictionary *logData = [[NSMutableDictionary alloc] init];
-  [FBSDKInternalUtility dictionary:logData setObject:targetURL.absoluteString forKey:@"targetURL"];
-  [FBSDKInternalUtility dictionary:logData setObject:targetURL.host forKey:@"targetURLHost"];
+  [FBSDKInternalUtility dictionary:logData setObject:[targetURL absoluteString] forKey:@"targetURL"];
+  [FBSDKInternalUtility dictionary:logData setObject:[targetURL host] forKey:@"targetURLHost"];
 
   NSDictionary *refererData = applinkData[@"referer_data"];
   if (refererData) {
@@ -524,8 +524,8 @@ static NSString *const FBSDKAppLinkInboundEvent = @"fb_al_inbound";
     [FBSDKInternalUtility dictionary:logData setObject:refererData[@"url"] forKey:@"referralURL"];
     [FBSDKInternalUtility dictionary:logData setObject:refererData[@"app_name"] forKey:@"referralAppName"];
   }
-  [FBSDKInternalUtility dictionary:logData setObject:url.absoluteString forKey:@"inputURL"];
-  [FBSDKInternalUtility dictionary:logData setObject:url.scheme forKey:@"inputURLScheme"];
+  [FBSDKInternalUtility dictionary:logData setObject:[url absoluteString] forKey:@"inputURL"];
+  [FBSDKInternalUtility dictionary:logData setObject:[url scheme] forKey:@"inputURLScheme"];
 
   [FBSDKAppEvents logImplicitEvent:FBSDKAppLinkInboundEvent
                         valueToSum:nil
@@ -536,27 +536,27 @@ static NSString *const FBSDKAppLinkInboundEvent = @"fb_al_inbound";
 - (void)_logSDKInitialize
 {
   NSMutableDictionary *params = [NSMutableDictionary new];
-  params[@"core_lib_included"] = @1;
+  [params setObject:@1 forKey:@"core_lib_included"];
   if (objc_lookUpClass("FBSDKShareDialog") != nil) {
-    params[@"share_lib_included"] = @1;
+    [params setObject:@1 forKey:@"share_lib_included"];
   }
   if (objc_lookUpClass("FBSDKLoginManager") != nil) {
-    params[@"login_lib_included"] = @1;
+    [params setObject:@1 forKey:@"login_lib_included"];
   }
   if (objc_lookUpClass("FBSDKPlacesManager") != nil) {
-    params[@"places_lib_included"] = @1;
+    [params setObject:@1 forKey:@"places_lib_included"];
   }
   if (objc_lookUpClass("FBSDKMessengerButton") != nil) {
-    params[@"messenger_lib_included"] = @1;
+    [params setObject:@1 forKey:@"messenger_lib_included"];
   }
   if (objc_lookUpClass("FBSDKMessengerButton") != nil) {
-    params[@"messenger_lib_included"] = @1;
+    [params setObject:@1 forKey:@"messenger_lib_included"];
   }
   if (objc_lookUpClass("FBSDKTVInterfaceFactory.m") != nil) {
-    params[@"tv_lib_included"] = @1;
+    [params setObject:@1 forKey:@"tv_lib_included"];
   }
   if (objc_lookUpClass("FBSDKAutoLog") != nil) {
-    params[@"marketing_lib_included"] = @1;
+    [params setObject:@1 forKey:@"marketing_lib_included"];
   }
   [FBSDKAppEvents logEvent:@"fb_sdk_initialize" parameters:params];
 }

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKButton.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKButton.m
@@ -76,7 +76,7 @@
 
 - (CGRect)imageRectForContentRect:(CGRect)contentRect
 {
-  if (self.hidden || CGRectIsEmpty(self.bounds)) {
+  if ([self isHidden] || CGRectIsEmpty(self.bounds)) {
     return CGRectZero;
   }
   CGRect imageRect = UIEdgeInsetsInsetRect(contentRect, self.imageEdgeInsets);
@@ -101,9 +101,9 @@
 {
   // automatic impression tracking if the button conforms to FBSDKButtonImpressionTracking
   if ([self conformsToProtocol:@protocol(FBSDKButtonImpressionTracking)]) {
-    NSString *eventName = ((id<FBSDKButtonImpressionTracking>)self).impressionTrackingEventName;
-    NSString *identifier = ((id<FBSDKButtonImpressionTracking>)self).impressionTrackingIdentifier;
-    NSDictionary<NSString *, id> *parameters = ((id<FBSDKButtonImpressionTracking>)self).analyticsParameters;
+    NSString *eventName = [(id<FBSDKButtonImpressionTracking>)self impressionTrackingEventName];
+    NSString *identifier = [(id<FBSDKButtonImpressionTracking>)self impressionTrackingIdentifier];
+    NSDictionary *parameters = [(id<FBSDKButtonImpressionTracking>)self analyticsParameters];
     if (eventName && identifier) {
       FBSDKViewImpressionTracker *impressionTracker = [FBSDKViewImpressionTracker impressionTrackerWithEventName:eventName];
       [impressionTracker logImpressionWithIdentifier:identifier parameters:parameters];
@@ -114,7 +114,7 @@
 
 - (CGSize)sizeThatFits:(CGSize)size
 {
-  if (self.hidden) {
+  if ([self isHidden]) {
     return CGSizeZero;
   }
   CGSize normalSize = [self sizeThatFits:size title:[self titleForState:UIControlStateNormal]];
@@ -131,7 +131,7 @@
 
 - (CGRect)titleRectForContentRect:(CGRect)contentRect
 {
-  if (self.hidden || CGRectIsEmpty(self.bounds)) {
+  if ([self isHidden] || CGRectIsEmpty(self.bounds)) {
     return CGRectZero;
   }
   CGRect imageRect = [self imageRectForContentRect:contentRect];
@@ -174,9 +174,9 @@
 
 - (void)checkImplicitlyDisabled
 {
-  BOOL enabled = !_isExplicitlyDisabled && !self.implicitlyDisabled;
-  BOOL currentEnabled = self.enabled;
-  super.enabled = enabled;
+  BOOL enabled = !_isExplicitlyDisabled && ![self isImplicitlyDisabled];
+  BOOL currentEnabled = [self isEnabled];
+  [super setEnabled:enabled];
   if (currentEnabled != enabled) {
     [self invalidateIntrinsicContentSize];
     [self setNeedsLayout];

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit.h
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit.h
@@ -53,5 +53,5 @@
 #import <FBSDKCoreKit/FBSDKDeviceViewControllerBase.h>
 #endif
 
-#define FBSDK_VERSION_STRING @"4.39.0"
+#define FBSDK_VERSION_STRING @"4.38.1"
 #define FBSDK_TARGET_PLATFORM_VERSION @"v3.2"

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphErrorRecoveryProcessor.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphErrorRecoveryProcessor.m
@@ -72,7 +72,7 @@
           return NO;
         };
 
-        if ([request.tokenString isEqualToString:[FBSDKSystemAccountStoreAdapter sharedInstance].accessTokenString] &&
+        if ([request.tokenString isEqualToString:[[FBSDKSystemAccountStoreAdapter sharedInstance] accessTokenString]] &&
             isLoginRecoveryAttempter) {
           // special system auth case: if user has granted permissions we can simply renew. On a successful
           // renew, treat this as immediately recovered without the standard alert prompty.

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphRequest.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphRequest.m
@@ -175,7 +175,7 @@ static NSString *const kPostHTTPMethod = @"POST";
   NSString *debugValue = [FBSDKSettings graphAPIDebugParamValue];
   if (debugValue) {
     NSMutableDictionary *mutableParams = [NSMutableDictionary dictionaryWithDictionary:params];
-    mutableParams[@"debug"] = debugValue;
+    [mutableParams setObject:debugValue forKey:@"debug"];
     return mutableParams;
   }
 
@@ -203,7 +203,7 @@ static NSString *const kPostHTTPMethod = @"POST";
   if (self.HTTPMethod) {
     [result appendFormat:@", HTTPMethod: %@", self.HTTPMethod];
   }
-  [result appendFormat:@", parameters: %@>", self.parameters.description];
+  [result appendFormat:@", parameters: %@>", [self.parameters description]];
   return result;
 }
 

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphRequestConnection.h
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphRequestConnection.h
@@ -221,13 +221,8 @@ totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite;
  to allow for using the request's response in a subsequent request.
  */
 - (void)addRequest:(FBSDKGraphRequest *)request
-    batchEntryName:(NSString *)name
- completionHandler:(FBSDKGraphRequestHandler)handler;
-
-- (void)addRequest:(FBSDKGraphRequest *)request
  completionHandler:(FBSDKGraphRequestHandler)handler
-    batchEntryName:(NSString *)name
-DEPRECATED_MSG_ATTRIBUTE("Renamed `addRequest:batchEntryName:completionHandler:`");
+    batchEntryName:(NSString *)name;
 
 /**
  @method
@@ -249,13 +244,8 @@ DEPRECATED_MSG_ATTRIBUTE("Renamed `addRequest:batchEntryName:completionHandler:`
  to allow for using the request's response in a subsequent request.
  */
 - (void)addRequest:(FBSDKGraphRequest *)request
-   batchParameters:(NSDictionary<NSString *, id> *)batchParameters
- completionHandler:(FBSDKGraphRequestHandler)handler;
-
-- (void)addRequest:(FBSDKGraphRequest *)request
  completionHandler:(FBSDKGraphRequestHandler)handler
-   batchParameters:(NSDictionary *)batchParameters
-DEPRECATED_MSG_ATTRIBUTE("Renamed `addRequest:batchParameters:completionHandler:`");
+   batchParameters:(NSDictionary *)batchParameters;
 
 /**
  @methodgroup Instance methods
@@ -313,10 +303,7 @@ DEPRECATED_MSG_ATTRIBUTE("Renamed `addRequest:batchParameters:completionHandler:
 
  @param version   This is a string in the form @"v2.0" which will be used for the version part of an API path
  */
-- (void)overrideGraphAPIVersion:(NSString *)version;
-
-- (void)overrideVersionPartWith:(NSString *)version
-DEPRECATED_MSG_ATTRIBUTE("Renamed `overrideGraphAPIVersion`");
+- (void)overrideVersionPartWith:(NSString *)version;
 
 @end
 

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphRequestConnection.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphRequestConnection.m
@@ -154,20 +154,20 @@ NSURLSessionDataDelegate
 - (void)addRequest:(FBSDKGraphRequest *)request
  completionHandler:(FBSDKGraphRequestHandler)handler
 {
-  [self addRequest:request batchEntryName:nil completionHandler:handler];
+  [self addRequest:request completionHandler:handler batchEntryName:nil];
 }
 
 - (void)addRequest:(FBSDKGraphRequest *)request
-    batchEntryName:(NSString *)name
  completionHandler:(FBSDKGraphRequestHandler)handler
+    batchEntryName:(NSString *)name
 {
   NSDictionary *batchParams = (name)? @{kBatchEntryName : name } : nil;
-  [self addRequest:request batchParameters:batchParams completionHandler:handler];
+  [self addRequest:request completionHandler:handler batchParameters:batchParams];
 }
 
 - (void)addRequest:(FBSDKGraphRequest *)request
-   batchParameters:(NSDictionary<NSString *, id> *)batchParameters
  completionHandler:(FBSDKGraphRequestHandler)handler
+   batchParameters:(NSDictionary *)batchParameters
 {
   if (self.state != kStateCreated) {
     @throw [NSException exceptionWithName:NSInternalInconsistencyException
@@ -181,20 +181,6 @@ NSURLSessionDataDelegate
   [self.requests addObject:metadata];
 }
 
-- (void)addRequest:(FBSDKGraphRequest *)request
- completionHandler:(FBSDKGraphRequestHandler)handler
-    batchEntryName:(NSString *)name
-{
-  [self addRequest:request batchEntryName:name completionHandler:handler];
-}
-
-- (void)addRequest:(FBSDKGraphRequest *)request
- completionHandler:(FBSDKGraphRequestHandler)handler
-   batchParameters:(NSDictionary *)batchParameters
-{
-  [self addRequest:request batchParameters:batchParameters completionHandler:handler];
-}
-
 - (void)cancel
 {
   self.state = kStateCancelled;
@@ -202,16 +188,11 @@ NSURLSessionDataDelegate
   [self cleanUpSession];
 }
 
-- (void)overrideGraphAPIVersion:(NSString *)version
+- (void)overrideVersionPartWith:(NSString *)version
 {
   if (![_overrideVersionPart isEqualToString:version]) {
     _overrideVersionPart = [version copy];
   }
-}
-
-- (void)overrideVersionPartWith:(NSString *)version
-{
-  [self overrideGraphAPIVersion:version];
 }
 
 - (void)start
@@ -303,13 +284,13 @@ NSURLSessionDataDelegate
     if ([FBSDKGraphRequest isAttachment:value]) {
       NSString *name = [NSString stringWithFormat:@"%@%lu",
                         kBatchFileNamePrefix,
-                        (unsigned long)attachments.count];
+                        (unsigned long)[attachments count]];
       [attachmentNames addObject:name];
       attachments[name] = value;
     }
   }];
 
-  if (attachmentNames.count) {
+  if ([attachmentNames count]) {
     requestElement[kBatchAttachmentKey] = [attachmentNames componentsJoinedByString:@","];
   }
 
@@ -431,16 +412,16 @@ NSURLSessionDataDelegate
 
   [self _validateFieldsParamForGetRequests:requests];
 
-  if (requests.count == 1) {
-    FBSDKGraphRequestMetadata *metadata = requests[0];
+  if ([requests count] == 1) {
+    FBSDKGraphRequestMetadata *metadata = [requests objectAtIndex:0];
     NSURL *url = [NSURL URLWithString:[self urlStringForSingleRequest:metadata.request forBatch:NO]];
     request = [NSMutableURLRequest requestWithURL:url
                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
                                   timeoutInterval:timeout];
 
     // HTTP methods are case-sensitive; be helpful in case someone provided a mixed case one.
-    NSString *httpMethod = metadata.request.HTTPMethod.uppercaseString;
-    request.HTTPMethod = httpMethod;
+    NSString *httpMethod = [metadata.request.HTTPMethod uppercaseString];
+    [request setHTTPMethod:httpMethod];
     [self appendAttachments:metadata.request.parameters
                      toBody:body
                 addFormData:[httpMethod isEqualToString:@"POST"]
@@ -476,11 +457,11 @@ NSURLSessionDataDelegate
     request = [NSMutableURLRequest requestWithURL:url
                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
                                   timeoutInterval:timeout];
-    request.HTTPMethod = @"POST";
+    [request setHTTPMethod:@"POST"];
   }
 
-  request.HTTPBody = body.data;
-  NSUInteger bodyLength = body.data.length / 1024;
+  [request setHTTPBody:[body data]];
+  NSUInteger bodyLength = [[body data] length] / 1024;
 
   [request setValue:[FBSDKGraphRequestConnection userAgent] forHTTPHeaderField:@"User-Agent"];
   [request setValue:[body mimeContentType] forHTTPHeaderField:@"Content-Type"];
@@ -520,17 +501,17 @@ NSURLSessionDataDelegate
     NSString *prefix = kGraphURLPrefix;
     // We special case a graph post to <id>/videos and send it to graph-video.facebook.com
     // We only do this for non batch post requests
-    NSString *graphPath = request.graphPath.lowercaseString;
-    if ([request.HTTPMethod.uppercaseString isEqualToString:@"POST"] &&
+    NSString *graphPath = [request.graphPath lowercaseString];
+    if ([[request.HTTPMethod uppercaseString] isEqualToString:@"POST"] &&
         [graphPath hasSuffix:@"/videos"]) {
       graphPath = [graphPath stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"/"]];
       NSArray *components = [graphPath componentsSeparatedByString:@"/"];
-      if (components.count == 2) {
+      if ([components count] == 2) {
         prefix = kGraphVideoURLPrefix;
       }
     }
 
-    baseURL = [FBSDKInternalUtility facebookURLWithHostPrefix:prefix path:request.graphPath queryParameters:nil defaultVersion:request.version error:NULL].absoluteString;
+    baseURL = [[FBSDKInternalUtility facebookURLWithHostPrefix:prefix path:request.graphPath queryParameters:nil defaultVersion:request.version error:NULL] absoluteString];
   }
 
   NSString *url = [FBSDKGraphRequest serializeURL:baseURL
@@ -577,23 +558,23 @@ NSURLSessionDataDelegate
   }
 
   if (!error) {
-    if (self.requests.count != results.count) {
+    if ([self.requests count] != [results count]) {
       error = [NSError fbErrorWithCode:FBSDKErrorGraphRequestProtocolMismatch
                                 message:@"Unexpected number of results returned from server."];
     } else {
       [_logger appendFormat:@"Response <#%lu>\nDuration: %llu msec\nSize: %lu kB\nResponse Body:\n%@\n\n",
-       (unsigned long)_logger.loggerSerialNumber,
+       (unsigned long)[_logger loggerSerialNumber],
        [FBSDKInternalUtility currentTimeInMilliseconds] - _requestStartTime,
-       (unsigned long)data.length,
+       (unsigned long)[data length],
        results];
     }
   }
 
   if (error) {
     [_logger appendFormat:@"Response <#%lu> <Error>:\n%@\n%@\n",
-     (unsigned long)_logger.loggerSerialNumber,
-     error.localizedDescription,
-     error.userInfo];
+     (unsigned long)[_logger loggerSerialNumber],
+     [error localizedDescription],
+     [error userInfo]];
   }
   [_logger emitToNSLog];
 
@@ -626,7 +607,7 @@ NSURLSessionDataDelegate
   id response = [self parseJSONOrOtherwise:responseUTF8 error:error];
 
   if (responseUTF8 == nil) {
-    NSString *base64Data = data.length != 0 ? [data base64EncodedStringWithOptions:0] : @"";
+    NSString *base64Data = [data length] != 0 ? [data base64EncodedStringWithOptions:0] : @"";
     if (base64Data != nil) {
       [FBSDKAppEvents logImplicitEvent:@"fb_response_invalid_utf8"
                             valueToSum:nil
@@ -644,7 +625,7 @@ NSURLSessionDataDelegate
                         innerError:nil
                            message:@"The server returned an unexpected response."];
     }
-  } else if (self.requests.count == 1) {
+  } else if ([self.requests count] == 1) {
     // response is the entry, so put it in a dictionary under "body" and add
     // that to array of responses.
     [results addObject:@{
@@ -722,11 +703,11 @@ NSURLSessionDataDelegate
 - (void)completeWithResults:(NSArray *)results
                networkError:(NSError *)networkError
 {
-  NSUInteger count = self.requests.count;
+  NSUInteger count = [self.requests count];
   _expectingResults = count;
   NSUInteger disabledRecoveryCount = 0;
   for (FBSDKGraphRequestMetadata *metadata in self.requests) {
-    if (metadata.request.graphErrorRecoveryDisabled) {
+    if ([metadata.request isGraphErrorRecoveryDisabled]) {
       disabledRecoveryCount++;
     }
   }
@@ -735,7 +716,7 @@ NSURLSessionDataDelegate
 #endif
 
   [self.requests enumerateObjectsUsingBlock:^(FBSDKGraphRequestMetadata *metadata, NSUInteger i, BOOL *stop) {
-    id result = networkError ? nil : results[i];
+    id result = networkError ? nil : [results objectAtIndex:i];
     NSError *resultError = networkError ?: [self errorFromResult:result request:metadata.request];
 
     id body = nil;
@@ -745,7 +726,7 @@ NSURLSessionDataDelegate
     }
 
 #if !TARGET_OS_TV
-    if (resultError && !metadata.request.graphErrorRecoveryDisabled && isSingleRequestToRecover) {
+    if (resultError && ![metadata.request isGraphErrorRecoveryDisabled] && isSingleRequestToRecover) {
       self->_recoveringRequestMetadata = metadata;
       self->_errorRecoveryProcessor = [[FBSDKGraphErrorRecoveryProcessor alloc] init];
       if ([self->_errorRecoveryProcessor processError:resultError request:metadata.request delegate:self]) {
@@ -767,7 +748,7 @@ NSURLSessionDataDelegate
 - (void)processResultBody:(NSDictionary *)body error:(NSError *)error metadata:(FBSDKGraphRequestMetadata *)metadata canNotifyDelegate:(BOOL)canNotifyDelegate
 {
   void (^finishAndInvokeCompletionHandler)(void) = ^{
-    NSDictionary<NSString *, id> *graphDebugDict = body[@"__debug__"];
+    NSDictionary *graphDebugDict = [body objectForKey:@"__debug__"];
     if ([graphDebugDict isKindOfClass:[NSDictionary class]]) {
       [self processResultDebugDictionary: graphDebugDict];
     }
@@ -840,7 +821,7 @@ NSURLSessionDataDelegate
 - (void)processResultDebugDictionary:(NSDictionary *)dict
 {
   NSArray *messages = [FBSDKTypeUtility arrayValue:dict[@"messages"]];
-  if (!messages.count) {
+  if (![messages count]) {
     return;
   }
 
@@ -946,8 +927,8 @@ NSURLSessionDataDelegate
 {
   if (_logger.isActive) {
     [_logger appendFormat:@"Request <#%lu>:\n", (unsigned long)_logger.loggerSerialNumber];
-    [_logger appendKey:@"URL" value:request.URL.absoluteString];
-    [_logger appendKey:@"Method" value:request.HTTPMethod];
+    [_logger appendKey:@"URL" value:[[request URL] absoluteString]];
+    [_logger appendKey:@"Method" value:[request HTTPMethod]];
     [_logger appendKey:@"UserAgent" value:[request valueForHTTPHeaderField:@"User-Agent"]];
     [_logger appendKey:@"MIME" value:[request valueForHTTPHeaderField:@"Content-Type"]];
 
@@ -1073,7 +1054,7 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
     if (comma) {
       [result appendString:@",\n"];
     }
-    [result appendString:request.description];
+    [result appendString:[request description]];
     comma = YES;
   }
   [result appendString:@"\n)>"];

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKProfile.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKProfile.m
@@ -144,13 +144,13 @@ static FBSDKProfile *g_currentProfile;
 - (NSUInteger)hash
 {
   NSUInteger subhashes[] = {
-    self.userID.hash,
-    self.firstName.hash,
-    self.middleName.hash,
-    self.lastName.hash,
-    self.name.hash,
-    self.linkURL.hash,
-    self.refreshDate.hash
+    [self.userID hash],
+    [self.firstName hash],
+    [self.middleName hash],
+    [self.lastName hash],
+    [self.name hash],
+    [self.linkURL hash],
+    [self.refreshDate hash]
   };
   return [FBSDKMath hashWithIntegerArray:subhashes count:sizeof(subhashes) / sizeof(subhashes[0])];
 }
@@ -183,7 +183,7 @@ static FBSDKProfile *g_currentProfile;
   return YES;
 }
 
-- (instancetype)initWithCoder:(NSCoder *)decoder
+- (id)initWithCoder:(NSCoder *)decoder
 {
   NSString *userID = [decoder decodeObjectOfClass:[NSString class] forKey:FBSDKPROFILE_USERID_KEY];
   NSString *firstName = [decoder decodeObjectOfClass:[NSString class] forKey:FBSDKPROFILE_FIRSTNAME_KEY];

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKProfilePictureView.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKProfilePictureView.m
@@ -69,7 +69,7 @@
     (NSUInteger)_size.height,
     (NSUInteger)_scale,
     (NSUInteger)_pictureMode,
-    _profileID.hash,
+    [_profileID hash],
   };
   return [FBSDKMath hashWithIntegerArray:subhashes count:sizeof(subhashes) / sizeof(subhashes[0])];
 }
@@ -119,7 +119,7 @@
   return self;
 }
 
-- (instancetype)initWithCoder:(NSCoder *)decoder
+- (id)initWithCoder:(NSCoder *)decoder
 {
   if ((self = [super initWithCoder:decoder])) {
     [self _configureProfilePictureView];
@@ -138,7 +138,7 @@
 {
   CGRect currentBounds = self.bounds;
   if (!CGRectEqualToRect(currentBounds, bounds)) {
-    super.bounds = bounds;
+    [super setBounds:bounds];
     if (!CGSizeEqualToSize(currentBounds.size, bounds.size)) {
       _placeholderImageIsValid = NO;
       [self setNeedsImageUpdate];
@@ -155,7 +155,7 @@
 {
   if (_imageView.contentMode != contentMode) {
     _imageView.contentMode = contentMode;
-    super.contentMode = contentMode;
+    [super setContentMode:contentMode];
     [self setNeedsImageUpdate];
   }
 }
@@ -240,7 +240,7 @@
 
 - (void)_accessTokenDidChangeNotification:(NSNotification *)notification
 {
-  if (![_profileID isEqualToString:@"me"] || !notification.userInfo[FBSDKAccessTokenDidChangeUserIDKey]) {
+  if (![_profileID isEqualToString:@"me"] || !notification.userInfo[FBSDKAccessTokenDidChangeUserID]) {
     return;
   }
   _lastState = nil;
@@ -327,7 +327,7 @@
   // leave the current value until the new resolution image is downloaded
   BOOL imageShouldFit = [self _imageShouldFit];
   UIScreen *screen = self.window.screen ?: [UIScreen mainScreen];
-  CGFloat scale = screen.scale;
+  CGFloat scale = [screen scale];
   CGSize imageSize = [self _imageSize:imageShouldFit scale:scale];
   FBSDKProfilePictureViewState *state = [[FBSDKProfilePictureViewState alloc] initWithProfileID:_profileID
                                                                                            size:imageSize

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKSettings.h
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKSettings.h
@@ -179,18 +179,6 @@ FOUNDATION_EXPORT NSString *const FBSDKLoggingBehaviorDeveloperErrors;
 + (void)setCodelessDebugLogEnabled:(NSNumber *)CodelessDebugLogEnabled;
 
 /**
- Flag which controls whether advertiserID could be collected.
- If not explicitly set, the default is 1 - true
- */
-+ (NSNumber *)advertiserIDCollectionEnabled;
-
-/**
- Set the flag which controls ontrols whether advertiserID could be collected.
- @param AdvertiserIDCollectionEnabled Flag value, expressed as a value from 0 - false or 1 - true.
- */
-+ (void)setAdvertiserIDCollectionEnabled:(NSNumber *)AdvertiserIDCollectionEnabled;
-
-/**
   Gets whether data such as that generated through FBSDKAppEvents and sent to Facebook should be restricted from being used for other than analytics and conversions.  Defaults to NO.  This value is stored on the device and persists across app launches.
  */
 + (BOOL)limitEventAndDataUsage;

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKSettings.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKSettings.m
@@ -77,8 +77,6 @@ FBSDKSETTINGS_PLIST_CONFIGURATION_SETTING_IMPL(NSNumber, FacebookAutoLogAppEvent
   setAutoLogAppEventsEnabled, @1);
 FBSDKSETTINGS_PLIST_CONFIGURATION_SETTING_IMPL(NSNumber, FacebookCodelessDebugLogEnabled, codelessDebugLogEnabled,
   setCodelessDebugLogEnabled, @0);
-FBSDKSETTINGS_PLIST_CONFIGURATION_SETTING_IMPL(NSNumber, FacebookAdvertiserIDCollectionEnabled, advertiserIDCollectionEnabled,
-  setAdvertiserIDCollectionEnabled, @1);
 
 + (void)setGraphErrorRecoveryDisabled:(BOOL)disableGraphErrorRecovery {
   g_disableErrorRecovery = disableGraphErrorRecovery;
@@ -90,7 +88,7 @@ FBSDKSETTINGS_PLIST_CONFIGURATION_SETTING_IMPL(NSNumber, FacebookAdvertiserIDCol
 
 + (CGFloat)JPEGCompressionQuality
 {
-  return [self _JPEGCompressionQualityNumber].floatValue;
+  return [[self _JPEGCompressionQualityNumber] floatValue];
 }
 
 + (void)setJPEGCompressionQuality:(CGFloat)JPEGCompressionQuality

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKTestUsersManager.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKTestUsersManager.m
@@ -126,7 +126,7 @@ static NSMutableDictionary *gInstancesDictionary;
                     completionHandler:(FBSDKTestUsersManagerRetrieveTestAccountTokensHandler)handler {
   NSDictionary *params = @{
                            @"installed" : @"true",
-                           @"permissions" : [permissions.allObjects componentsJoinedByString:@","],
+                           @"permissions" : [[permissions allObjects] componentsJoinedByString:@","],
                            @"access_token" : self.appAccessToken
                            };
   FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:[NSString stringWithFormat:kFBGraphAPITestUsersPathFormat, _appID]
@@ -179,16 +179,12 @@ static NSMutableDictionary *gInstancesDictionary;
                                                                 version:nil
                                                              HTTPMethod:@"POST"];
   FBSDKGraphRequestConnection *conn = [[FBSDKGraphRequestConnection alloc] init];
-  [conn addRequest:one
-    batchEntryName:@"first"
- completionHandler:^(FBSDKGraphRequestConnection *connection, id result, NSError *error) {
+  [conn addRequest:one completionHandler:^(FBSDKGraphRequestConnection *connection, id result, NSError *error) {
     complete(error);
-  }];
-  [conn addRequest:two
-   batchParameters:@{ @"depends_on" : @"first"}
- completionHandler:^(FBSDKGraphRequestConnection *connection, id result, NSError *error) {
+  } batchEntryName:@"first"];
+  [conn addRequest:two completionHandler:^(FBSDKGraphRequestConnection *connection, id result, NSError *error) {
     complete(error);
-  }];
+  } batchParameters:@{ @"depends_on" : @"first"} ];
   [conn start];
 }
 
@@ -209,7 +205,7 @@ static NSMutableDictionary *gInstancesDictionary;
 #pragma mark - private methods
 - (FBSDKAccessToken *)tokenDataForTokenString:(NSString *)tokenString permissions:(NSSet *)permissions userId:(NSString *)userId{
   return [[FBSDKAccessToken alloc] initWithTokenString:tokenString
-                                           permissions:permissions.allObjects
+                                           permissions:[permissions allObjects]
                                    declinedPermissions:nil
                                                  appID:_appID
                                                 userID:userId

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKURL.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKURL.m
@@ -88,14 +88,14 @@
                 if (sourceApplication) {
                     logData[@"sourceApplication"] = sourceApplication;
                 }
-                if (_targetURL.absoluteString) {
-                    logData[@"targetURL"] = _targetURL.absoluteString;
+                if ([_targetURL absoluteString]) {
+                    logData[@"targetURL"] = [_targetURL absoluteString];
                 }
-                if (_inputURL.absoluteString) {
-                    logData[@"inputURL"] = _inputURL.absoluteString;
+                if ([_inputURL absoluteString]) {
+                    logData[@"inputURL"] = [_inputURL absoluteString];
                 }
-                if (_inputURL.scheme) {
-                    logData[@"inputURLScheme"] = _inputURL.scheme;
+                if ([_inputURL scheme]) {
+                    logData[@"inputURLScheme"] = [_inputURL scheme];
                 }
                 logData[@"forRenderBackToReferrerBar"] = forRenderBackToReferrerBar ? EVENT_YES_VAL : EVENT_NO_VAL;
                 logData[@"forOpenUrl"] = forOpenURLEvent ? EVENT_YES_VAL : EVENT_NO_VAL;

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKUtility.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKUtility.m
@@ -30,7 +30,7 @@
   NSArray *parts = [queryString componentsSeparatedByString:@"&"];
 
   for (NSString *part in parts) {
-    if (part.length == 0) {
+    if ([part length] == 0) {
       continue;
     }
 
@@ -67,15 +67,11 @@
           withString:@" "].stringByRemovingPercentEncoding;
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (NSString *)URLEncode:(NSString *)value
 {
-  NSCharacterSet *urlAllowedSet = [NSCharacterSet
-                                   characterSetWithCharactersInString:@" !*();:'@&=+$,/?%#[]\""].invertedSet;
+  NSCharacterSet *urlAllowedSet = [NSCharacterSet URLFragmentAllowedCharacterSet];
   return [value stringByAddingPercentEncodingWithAllowedCharacters:urlAllowedSet];
 }
-#pragma clang diagnostic pop
 
 + (dispatch_source_t)startGCDTimerWithInterval:(double)interval block:(dispatch_block_t)block
 {

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKWebViewAppLinkResolver.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/FBSDKWebViewAppLinkResolver.m
@@ -289,7 +289,7 @@ static NSString *const FBSDKWebViewAppLinkResolverShouldFallbackKey = @"should_f
     NSURL *webUrl = destination;
 
     if (shouldFallbackString &&
-        [@[ @"no", @"false", @"0" ] containsObject:shouldFallbackString.lowercaseString]) {
+        [@[ @"no", @"false", @"0" ] containsObject:[shouldFallbackString lowercaseString]]) {
         webUrl = nil;
     }
     if (webUrl && webUrlString) {

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/Codeless/FBSDKCodelessIndexer.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/Codeless/FBSDKCodelessIndexer.m
@@ -83,7 +83,7 @@ static NSString *_lastTreeHash;
   [request startWithCompletionHandler:^(FBSDKGraphRequestConnection *connection, id result, NSError *error) {
     _isCheckingSession = NO;
     if ([result isKindOfClass:[NSDictionary class]]) {
-      _isCodelessIndexingEnabled = [((NSDictionary *)result)[CODELESS_INDEXING_STATUS_KEY] boolValue];
+      _isCodelessIndexingEnabled = [[(NSDictionary *)result objectForKey:CODELESS_INDEXING_STATUS_KEY] boolValue];
       if (_isCodelessIndexingEnabled) {
         _lastTreeHash = nil;
         if (!_appIndexingTimer) {
@@ -105,7 +105,7 @@ static NSString *_lastTreeHash;
 + (NSString *)currentSessionDeviceID
 {
   if (!_deviceSessionID) {
-    _deviceSessionID = [NSUUID UUID].UUIDString;
+    _deviceSessionID = [[NSUUID UUID] UUIDString];
   }
   return _deviceSessionID;
 }
@@ -115,8 +115,12 @@ static NSString *_lastTreeHash;
   struct utsname systemInfo;
   uname(&systemInfo);
   NSString *machine = @(systemInfo.machine);
-  NSString *advertiserID = [FBSDKAppEventsUtility advertiserID] ?: @"";
+  NSString *advertiserID = nil;
+  if (FBSDKAdvertisingTrackingAllowed == [FBSDKAppEventsUtility advertisingTrackingStatus]) {
+    advertiserID = [FBSDKAppEventsUtility advertiserID];
+  }
   machine = machine ?: @"";
+  advertiserID = advertiserID ?: @"";
   NSString *debugStatus = [FBSDKAppEventsUtility isDebugBuild] ? @"1" : @"0";
 #if TARGET_IPHONE_SIMULATOR
   NSString *isSimulator = @"1";
@@ -126,7 +130,7 @@ static NSString *_lastTreeHash;
   NSLocale *locale = [NSLocale currentLocale];
   NSString *languageCode = [locale objectForKey:NSLocaleLanguageCode];
   NSString *countryCode = [locale objectForKey:NSLocaleCountryCode];
-  NSString *localeString = locale.localeIdentifier;
+  NSString *localeString = [locale localeIdentifier];
   if (languageCode && countryCode) {
     localeString = [NSString stringWithFormat:@"%@_%@", languageCode, countryCode];
   }
@@ -212,7 +216,7 @@ static NSString *_lastTreeHash;
     [request startWithCompletionHandler:^(FBSDKGraphRequestConnection *connection, id result, NSError *error) {
         _isCodelessIndexing = NO;
         if ([result isKindOfClass:[NSDictionary class]]) {
-            _isCodelessIndexingEnabled = [result[CODELESS_INDEXING_STATUS_KEY] boolValue];
+            _isCodelessIndexingEnabled = [[result objectForKey:CODELESS_INDEXING_STATUS_KEY] boolValue];
             if (!_isCodelessIndexingEnabled) {
                 _deviceSessionID = nil;
             }
@@ -240,15 +244,15 @@ static NSString *_lastTreeHash;
     return nil;
   }
 
-  NSArray *viewTrees = [trees reverseObjectEnumerator].allObjects;
+  NSArray *viewTrees = [[trees reverseObjectEnumerator] allObjects];
 
   NSData *data = UIImageJPEGRepresentation([FBSDKCodelessIndexer screenshot], 0.5);
   NSString *screenshot = [data base64EncodedStringWithOptions:0];
 
   NSMutableDictionary *treeInfo = [NSMutableDictionary dictionary];
 
-  treeInfo[@"view"] = viewTrees;
-  treeInfo[@"screenshot"] = screenshot ?: @"";
+  [treeInfo setObject:viewTrees forKey:@"view"];
+  [treeInfo setObject:screenshot ?: @"" forKey:@"screenshot"];
 
   NSString *tree = nil;
   data = [NSJSONSerialization dataWithJSONObject:treeInfo options:0 error:nil];
@@ -282,7 +286,7 @@ static NSString *_lastTreeHash;
 }
 
 + (UIImage *)screenshot {
-  UIWindow *window = [UIApplication sharedApplication].delegate.window;
+  UIWindow *window = [[UIApplication sharedApplication].delegate window];
 
   UIGraphicsBeginImageContext(window.bounds.size);
   [window drawViewHierarchyInRect:window.bounds afterScreenUpdates:YES];

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/Codeless/FBSDKCodelessParameterComponent.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/Codeless/FBSDKCodelessParameterComponent.m
@@ -25,14 +25,15 @@
 
 - (instancetype)initWithJSON:(NSDictionary *)dict {
   if (self = [super init]) {
-    _name = [dict[CODELESS_MAPPING_PARAMETER_NAME_KEY] copy];
-    _value = [dict[CODELESS_MAPPING_PARAMETER_VALUE_KEY] copy];
-    _pathType = [dict[CODELESS_MAPPING_PATH_TYPE_KEY] copy];
+    _name = [[dict objectForKey:CODELESS_MAPPING_PARAMETER_NAME_KEY] copy];
+    _value = [[dict objectForKey:CODELESS_MAPPING_PARAMETER_VALUE_KEY] copy];
+    _pathType = [[dict objectForKey:CODELESS_MAPPING_PATH_TYPE_KEY] copy];
 
-    NSArray *ary = dict[CODELESS_MAPPING_PATH_KEY];
+    NSArray *ary = [dict objectForKey:CODELESS_MAPPING_PATH_KEY];
     NSMutableArray *mut = [NSMutableArray array];
     for (NSDictionary *info in ary) {
-      FBSDKCodelessPathComponent *component = [[FBSDKCodelessPathComponent alloc] initWithJSON:info];
+      FBSDKCodelessPathComponent *component = [[FBSDKCodelessPathComponent alloc]
+                                            initWithJSON:info];
       [mut addObject:component];
     }
     _path = [mut copy];

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/Codeless/FBSDKCodelessPathComponent.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/Codeless/FBSDKCodelessPathComponent.m
@@ -24,32 +24,32 @@
 
 - (instancetype)initWithJSON:(NSDictionary *)dict {
   if (self = [super init]) {
-    _className = [dict[CODELESS_MAPPING_CLASS_NAME_KEY] copy];
-    _text = [dict[CODELESS_MAPPING_TEXT_KEY] copy];
-    _hint = [dict[CODELESS_MAPPING_HINT_KEY] copy];
-    _desc = [dict[CODELESS_MAPPING_DESC_KEY] copy];
+    _className = [[dict objectForKey:CODELESS_MAPPING_CLASS_NAME_KEY] copy];
+    _text = [[dict objectForKey:CODELESS_MAPPING_TEXT_KEY] copy];
+    _hint = [[dict objectForKey:CODELESS_MAPPING_HINT_KEY] copy];
+    _desc = [[dict objectForKey:CODELESS_MAPPING_DESC_KEY] copy];
 
 
-    if (dict[CODELESS_MAPPING_INDEX_KEY]) {
-      _index = [dict[CODELESS_MAPPING_INDEX_KEY] intValue];
+    if ([dict objectForKey:CODELESS_MAPPING_INDEX_KEY]) {
+      _index = [[dict objectForKey:CODELESS_MAPPING_INDEX_KEY] intValue];
     } else {
       _index = -1;
     }
 
-    if (dict[CODELESS_MAPPING_SECTION_KEY]) {
-      _section = [dict[CODELESS_MAPPING_SECTION_KEY] intValue];
+    if ([dict objectForKey:CODELESS_MAPPING_SECTION_KEY]) {
+      _section = [[dict objectForKey:CODELESS_MAPPING_SECTION_KEY] intValue];
     } else {
       _section = -1;
     }
 
-    if (dict[CODELESS_MAPPING_ROW_KEY]) {
-      _row = [dict[CODELESS_MAPPING_ROW_KEY] intValue];
+    if ([dict objectForKey:CODELESS_MAPPING_ROW_KEY]) {
+      _row = [[dict objectForKey:CODELESS_MAPPING_ROW_KEY] intValue];
     } else {
       _row = -1;
     }
 
-    _tag = [dict[CODELESS_MAPPING_TAG_KEY] intValue];
-    _matchBitmask = [dict[CODELESS_MAPPING_MATCH_BITMASK_KEY] intValue];
+    _tag = [[dict objectForKey:CODELESS_MAPPING_TAG_KEY] intValue];
+    _matchBitmask = [[dict objectForKey:CODELESS_MAPPING_MATCH_BITMASK_KEY] intValue];
   }
 
   return self;

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/Codeless/FBSDKEventBinding.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/Codeless/FBSDKEventBinding.m
@@ -37,23 +37,25 @@
 - (FBSDKEventBinding *)initWithJSON:(NSDictionary *)dict
 {
   if ((self = [super init])) {
-    _eventName = [dict[CODELESS_MAPPING_EVENT_NAME_KEY] copy];
-    _eventType = [dict[CODELESS_MAPPING_EVENT_TYPE_KEY] copy];
-    _appVersion = [dict[CODELESS_MAPPING_APP_VERSION_KEY] copy];
-    _pathType = [dict[CODELESS_MAPPING_PATH_TYPE_KEY] copy];
+    _eventName = [[dict objectForKey:CODELESS_MAPPING_EVENT_NAME_KEY] copy];
+    _eventType = [[dict objectForKey:CODELESS_MAPPING_EVENT_TYPE_KEY] copy];
+    _appVersion = [[dict objectForKey:CODELESS_MAPPING_APP_VERSION_KEY] copy];
+    _pathType = [[dict objectForKey:CODELESS_MAPPING_PATH_TYPE_KEY] copy];
 
-    NSArray *pathComponents = dict[CODELESS_MAPPING_PATH_KEY];
+    NSArray *pathComponents = [dict objectForKey:CODELESS_MAPPING_PATH_KEY];
     NSMutableArray *mut = [NSMutableArray array];
     for (NSDictionary *info in pathComponents) {
-      FBSDKCodelessPathComponent *component = [[FBSDKCodelessPathComponent alloc] initWithJSON:info];
+      FBSDKCodelessPathComponent *component = [[FBSDKCodelessPathComponent alloc]
+                                                       initWithJSON:info];
       [mut addObject:component];
     }
     _path = [mut copy];
 
-    NSArray *parameters = dict[CODELESS_MAPPING_PARAMETERS_KEY];
+    NSArray *parameters = [dict objectForKey:CODELESS_MAPPING_PARAMETERS_KEY];
     mut = [NSMutableArray array];
     for (NSDictionary *info in parameters) {
-      FBSDKCodelessParameterComponent *component = [[FBSDKCodelessParameterComponent alloc] initWithJSON:info];
+      FBSDKCodelessParameterComponent *component = [[FBSDKCodelessParameterComponent alloc]
+                                            initWithJSON:info];
       [mut addObject:component];
     }
     _parameters = [mut copy];
@@ -65,7 +67,7 @@
 {
   UIView *sourceView = [sender isKindOfClass:[UIView class]] ? (UIView *)sender : nil;
   NSMutableDictionary *params = [NSMutableDictionary dictionary];
-  params[CODELESS_CODELESS_EVENT_KEY] = @"1";
+  [params setObject:@"1" forKey:CODELESS_CODELESS_EVENT_KEY];
   for (FBSDKCodelessParameterComponent *component in self.parameters) {
     NSString *text = component.value;
     if (!text || text.length == 0) {
@@ -76,9 +78,9 @@
     if (text) {
       if ([component.name isEqualToString:PARAMETER_NAME_PRICE]) {
         NSNumber *value = [FBSDKAppEventsUtility getNumberValue:text];
-        params[component.name] = value;
+        [params setObject:value forKey:component.name];
       } else {
-        params[component.name] = text;
+        [params setObject:text forKey:component.name];
       }
     }
   }
@@ -160,8 +162,8 @@ pathComponent:(FBSDKCodelessPathComponent *)component
     NSInteger idxPath = path.count - i - 1;
     NSInteger idxViewPath = viewPath.count - i - 1;
 
-    FBSDKCodelessPathComponent *pathComponent = path[idxPath];
-    FBSDKCodelessPathComponent *viewPathComponent = viewPath[idxViewPath];
+    FBSDKCodelessPathComponent *pathComponent = [path objectAtIndex:idxPath];
+    FBSDKCodelessPathComponent *viewPathComponent = [viewPath objectAtIndex:idxViewPath];
 
     if (![pathComponent.className isEqualToString:viewPathComponent.className]) {
       return NO;
@@ -204,7 +206,7 @@ pathComponent:(FBSDKCodelessPathComponent *)component
     return nil;
   }
 
-  FBSDKCodelessPathComponent *pathComponent = path[level];
+  FBSDKCodelessPathComponent *pathComponent = [path objectAtIndex:level];
 
   //  If found parent, skip to next level
   if ([pathComponent.className isEqualToString:CODELESS_MAPPING_PARENT_CLASS_NAME]) {
@@ -230,7 +232,7 @@ pathComponent:(FBSDKCodelessPathComponent *)component
   if (path.count - 1 == level) {
     int index = pathComponent.index;
     if (index >= 0) {
-      NSObject *child = index < children.count ? children[index] : nil;
+      NSObject *child = index < children.count ? [children objectAtIndex:index] : nil;
       if ([self match:child pathComponent:pathComponent]) {
         return child;
       }

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/Codeless/FBSDKEventBindingManager.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/Codeless/FBSDKEventBindingManager.m
@@ -165,12 +165,12 @@ static void fb_dispatch_on_default_thread(dispatch_block_t block) {
       if ([event isKindOfClass:objc_lookUpClass(ReactNativeClassRCTTouchEvent)]) {
         @try {
           NSArray<id> *eventArgs = [event arguments];
-          NSString *eventName = eventArgs[0];
-          NSArray<NSDictionary *> *touches = eventArgs[1];
+          NSString *eventName = [eventArgs objectAtIndex:0];
+          NSArray<NSDictionary *> *touches = [eventArgs objectAtIndex:1];
           if (eventName && touches && [eventName isEqualToString:ReactNativeTouchEndEventName]) {
             for (NSDictionary<NSString *, id> *touch in touches) {
               NSNumber *targetTag = touch[ReactNativeTargetKey];
-              FBSDKEventBinding *eventBinding = self->reactBindings[targetTag];
+              FBSDKEventBinding *eventBinding = [self->reactBindings objectForKey:targetTag];
               if (eventBinding) {
                 [eventBinding trackEvent:nil];
               }
@@ -287,20 +287,24 @@ static void fb_dispatch_on_default_thread(dispatch_block_t block) {
         }
       } else if (self->hasReactNative
                  && [view respondsToSelector:@selector(reactTag)]) {
-        for (FBSDKEventBinding *binding in self->eventBindings) {
-          if ([FBSDKEventBinding isPath:binding.path matchViewPath:path]) {
-            fb_dispatch_on_main_thread(^{
-              // React Native touchable event is targeted at first subview,
-              // so extract the first subview and set the binding for it
-              UIView *reactView = view.subviews.firstObject;
-              if (reactView) {
-                NSNumber *reactTag = [FBSDKViewHierarchy getViewReactTag:reactView];
-                if (reactTag != nil) {
-                  self->reactBindings[reactTag] = binding;
+        Class classRCTTextView = objc_lookUpClass(ReactNativeClassRCTTextView);
+        if (classRCTTextView) {
+          for (FBSDKEventBinding *binding in self->eventBindings) {
+            if ([FBSDKEventBinding isPath:binding.path matchViewPath:path]) {
+              fb_dispatch_on_main_thread(^{
+                // React Native button's event is targeted at RCTTextView,
+                // so extract the RCTTextView and set the binding for it
+                UIView *reactView = [[view subviews] firstObject];
+                UIView *reactTextView = [[reactView subviews] firstObject];
+                if (reactTextView && [reactTextView isKindOfClass:classRCTTextView]) {
+                  NSNumber *reactTag = [reactTextView performSelector:@selector(reactTag)];
+                  if (reactTag && [reactTag isKindOfClass:[NSNumber class]]) {
+                    [self->reactBindings setObject:binding forKey:reactTag];
+                  }
                 }
-              }
-            });
-            break;
+              });
+              break;
+            }
           }
         }
       } else if ([view isKindOfClass:[UITableView class]]
@@ -318,7 +322,7 @@ static void fb_dispatch_on_default_thread(dispatch_block_t block) {
           }
 
           if (matchedBindings.count > 0) {
-            NSArray *bindings = matchedBindings.allObjects;
+            NSArray *bindings = [matchedBindings allObjects];
             void (^block)(id, SEL, id, id) = ^(id target, SEL command, UITableView *tableView, NSIndexPath *indexPath) {
               fb_dispatch_on_main_thread(^{
                 for (FBSDKEventBinding *binding in bindings) {
@@ -352,7 +356,7 @@ static void fb_dispatch_on_default_thread(dispatch_block_t block) {
           }
 
           if (matchedBindings.count > 0) {
-            NSArray *bindings = matchedBindings.allObjects;
+            NSArray *bindings = [matchedBindings allObjects];
             void (^block)(id, SEL, id, id) = ^(id target, SEL command, UICollectionView *collectionView, NSIndexPath *indexPath) {
               fb_dispatch_on_main_thread(^{
                 for (FBSDKEventBinding *binding in bindings) {

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/Codeless/FBSDKViewHierarchy.h
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/Codeless/FBSDKViewHierarchy.h
@@ -33,6 +33,5 @@
 + (UITableView *)getParentTableView:(UIView *)cell;
 + (UICollectionView *)getParentCollectionView:(UIView *)cell;
 + (NSInteger)getTag:(NSObject *)obj;
-+ (NSNumber *)getViewReactTag:(UIView *)view;
 
 @end

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/Codeless/FBSDKViewHierarchy.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/Codeless/FBSDKViewHierarchy.m
@@ -64,7 +64,7 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
   // children of window should be viewcontroller
   if ([obj isKindOfClass:[UIWindow class]]) {
     UIViewController *rootVC = ((UIWindow *)obj).rootViewController;
-    NSArray<UIView *> *subviews = ((UIWindow *)obj).subviews;
+    NSArray *subviews = [(UIWindow *)obj subviews];
     for (UIView *child in subviews) {
       if (child != rootVC.view) {
         UIViewController *vc = [FBSDKViewHierarchy getParentViewController:child];
@@ -80,7 +80,7 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
       }
     }
   } else if ([obj isKindOfClass:[UIView class]]) {
-    NSArray<UIView *> *subviews = [((UIView *)obj).subviews copy];
+    NSArray *subviews = [[(UIView *)obj subviews] copy];
     for (UIView *child in subviews) {
       UIViewController *vc = [FBSDKViewHierarchy getParentViewController:child];
       if (vc && vc.view == child) {
@@ -90,8 +90,8 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
       }
     }
   } else if ([obj isKindOfClass:[UINavigationController class]]) {
-    UIViewController *vc = ((UINavigationController*)obj).visibleViewController;
-    UIViewController *tc = ((UINavigationController*)obj).topViewController;
+    UIViewController *vc = [(UINavigationController*)obj visibleViewController];
+    UIViewController *tc = [(UINavigationController*)obj topViewController];
     NSArray *nextChildren = [FBSDKViewHierarchy getChildren:((UIViewController*)obj).view];
     for (NSObject *child in nextChildren) {
       if (tc && [self isView:child superViewOfView:tc.view]) {
@@ -115,7 +115,7 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
       [children addObject:vc];
     }
   } else if ([obj isKindOfClass:[UITabBarController class]]) {
-    UIViewController *vc = ((UITabBarController *)obj).selectedViewController;
+    UIViewController *vc = [(UITabBarController *)obj selectedViewController];
     NSArray *nextChildren = [FBSDKViewHierarchy getChildren:((UIViewController*)obj).view];
     for (NSObject *child in nextChildren) {
       if (vc && [self isView:child superViewOfView:vc.view]) {
@@ -140,7 +140,7 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
         [children addObjectsFromArray:nextChildren];
       }
     }
-    for (NSObject *child in vc.childViewControllers) {
+    for (NSObject *child in [vc childViewControllers]) {
       [children addObject:child];
     }
     UIViewController *presentedVC = vc.presentedViewController;
@@ -154,7 +154,7 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
 + (NSObject *)getParent:(NSObject *)obj
 {
   if ([obj isKindOfClass:[UIView class]]) {
-    UIView *superview = ((UIView *)obj).superview;
+    UIView *superview = [(UIView *)obj superview];
     UIViewController *superviewViewController = [FBSDKViewHierarchy
                                                  getParentViewController:superview];
     if (superviewViewController && superviewViewController.view == superview) {
@@ -166,10 +166,10 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
   }
   else if ([obj isKindOfClass:[UIViewController class]]) {
     UIViewController *vc = (UIViewController *)obj;
-    UIViewController *parentVC = vc.parentViewController;
-    UIViewController *presentingVC = vc.presentingViewController;
-    UINavigationController *nav = vc.navigationController;
-    UITabBarController *tab = vc.tabBarController;
+    UIViewController *parentVC = [vc parentViewController];
+    UIViewController *presentingVC = [vc presentingViewController];
+    UINavigationController *nav = [vc navigationController];
+    UITabBarController *tab = [vc tabBarController];
 
     if (nav) {
       return nav;
@@ -183,7 +183,7 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
       return parentVC;
     }
 
-    if (presentingVC && presentingVC.presentedViewController == vc) {
+    if (presentingVC && [presentingVC presentedViewController] == vc) {
       return presentingVC;
     }
 
@@ -229,35 +229,40 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
 + (NSDictionary<NSString *, id> *)getAttributesOf:(NSObject *)obj parent:(NSObject *)parent
 {
   NSMutableDictionary *componentInfo = [NSMutableDictionary dictionary];
-  componentInfo[CODELESS_MAPPING_CLASS_NAME_KEY] = NSStringFromClass([obj class]);
+  [componentInfo setObject:NSStringFromClass([obj class])
+                    forKey:CODELESS_MAPPING_CLASS_NAME_KEY];
 
   NSString *text = [FBSDKViewHierarchy getText:obj];
   if (text) {
-    componentInfo[CODELESS_MAPPING_TEXT_KEY] = text;
+    [componentInfo setObject:text forKey:CODELESS_MAPPING_TEXT_KEY];
   }
 
   NSString *hint = [FBSDKViewHierarchy getHint:obj];
   if (hint) {
-    componentInfo[CODELESS_MAPPING_HINT_KEY] = hint;
+    [componentInfo setObject:hint forKey:CODELESS_MAPPING_HINT_KEY];
   }
 
   NSIndexPath *indexPath = [FBSDKViewHierarchy getIndexPath:obj];
   if (indexPath) {
-    componentInfo[CODELESS_MAPPING_SECTION_KEY] = @(indexPath.section);
-    componentInfo[CODELESS_MAPPING_ROW_KEY] = @(indexPath.row);
+    [componentInfo setObject:@(indexPath.section)
+                      forKey:CODELESS_MAPPING_SECTION_KEY];
+    [componentInfo setObject:@(indexPath.row)
+                      forKey:CODELESS_MAPPING_ROW_KEY];
   }
 
   if (parent != nil) {
     NSArray *children = [FBSDKViewHierarchy getChildren:parent];
     NSUInteger index = [children indexOfObject:obj];
     if (index != NSNotFound) {
-      componentInfo[CODELESS_MAPPING_INDEX_KEY] = @(index);
+      [componentInfo setObject:@(index)
+                        forKey:CODELESS_MAPPING_INDEX_KEY];
     }
   } else {
-    componentInfo[CODELESS_MAPPING_INDEX_KEY] = @0;
+    [componentInfo setObject:@0 forKey:CODELESS_MAPPING_INDEX_KEY];
   }
 
-  componentInfo[CODELESS_VIEW_TREE_TAG_KEY] = @([FBSDKViewHierarchy getTag:obj]);
+  [componentInfo setObject:@([FBSDKViewHierarchy getTag:obj])
+                    forKey:CODELESS_VIEW_TREE_TAG_KEY];
 
   return [componentInfo copy];
 }
@@ -275,16 +280,17 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
   NSMutableDictionary *result = [NSMutableDictionary dictionaryWithDictionary:simpleAttributes];
 
   NSString *className = NSStringFromClass([obj class]);
-  result[CODELESS_VIEW_TREE_CLASS_NAME_KEY] = className;
+  [result setObject:className forKey:CODELESS_VIEW_TREE_CLASS_NAME_KEY];
 
   NSUInteger classBitmask = [FBSDKViewHierarchy getClassBitmask:obj];
-  result[CODELESS_VIEW_TREE_CLASS_TYPE_BIT_MASK_KEY] = [NSString stringWithFormat:@"%lu", (unsigned long)classBitmask];
+  [result setObject:[NSString stringWithFormat:@"%lu", (unsigned long)classBitmask]
+             forKey:CODELESS_VIEW_TREE_CLASS_TYPE_BIT_MASK_KEY];
 
   if ([obj isKindOfClass:[UIControl class]]) {
     // Get actions of UIControl
     UIControl *control = (UIControl *)obj;
     NSMutableSet *actions = [NSMutableSet set];
-    NSSet *targets = control.allTargets;
+    NSSet *targets = [control allTargets];
     for (NSObject *target in targets) {
       NSArray *ary = [control actionsForTarget:target forControlEvent:0];
       if (ary.count > 0) {
@@ -292,15 +298,16 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
       }
     }
     if (targets.count > 0) {
-      result[CODELESS_VIEW_TREE_ACTIONS_KEY] = actions.allObjects;
+      [result setObject:[actions allObjects] forKey:CODELESS_VIEW_TREE_ACTIONS_KEY];
     }
   }
 
-  result[CODELESS_VIEW_TREE_DIMENSION_KEY] = [FBSDKViewHierarchy getDimensionOf:obj];
+  [result setObject:[FBSDKViewHierarchy getDimensionOf:obj]
+             forKey:CODELESS_VIEW_TREE_DIMENSION_KEY];
 
   NSDictionary<NSString *, id> *textStyle = [FBSDKViewHierarchy getTextStyle:obj];
   if (textStyle) {
-    result[CODELESS_VIEW_TREE_TEXT_STYLE_KEY] = textStyle;
+    [result setObject:textStyle forKey:CODELESS_VIEW_TREE_TEXT_STYLE_KEY];
   }
 
   return result;
@@ -326,14 +333,14 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
   NSString *text = nil;
 
   if ([obj isKindOfClass:[UIButton class]]) {
-    text = ((UIButton *)obj).currentTitle;
+    text = [(UIButton *)obj currentTitle];
   } else if ([obj isKindOfClass:[UITextView class]] ||
              [obj isKindOfClass:[UITextField class]] ||
              [obj isKindOfClass:[UILabel class]]) {
-    text = ((UILabel *)obj).text;
+    text = [(UILabel *)obj text];
   } else if ([obj isKindOfClass:[UIPickerView class]]) {
     UIPickerView *picker = (UIPickerView *)obj;
-    NSInteger sections = picker.numberOfComponents;
+    NSInteger sections = [picker numberOfComponents];
     NSMutableArray *titles = [NSMutableArray array];
 
     for (NSInteger i = 0; i < sections; i++) {
@@ -344,9 +351,9 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
         title = [picker.delegate pickerView:picker titleForRow:row forComponent:i];
       } else if ([picker.delegate
                   respondsToSelector:@selector(pickerView:attributedTitleForRow:forComponent:)]) {
-        title = [picker.delegate
-                 pickerView:picker
-                 attributedTitleForRow:row forComponent:i].string;
+        title = [[picker.delegate
+                  pickerView:picker
+                  attributedTitleForRow:row forComponent:i] string];
       }
       [titles addObject:title ?: @""];
     }
@@ -359,23 +366,23 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
   } else if ([obj isKindOfClass:[UIDatePicker class]]) {
     UIDatePicker *picker = (UIDatePicker *)obj;
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    formatter.dateFormat = @"yyyy-MM-dd HH:mm:ssZ";
+    [formatter setDateFormat:@"yyyy-MM-dd HH:mm:ssZ"];
     text = [formatter stringFromDate:picker.date];
   } else if ([obj isKindOfClass:objc_lookUpClass("RCTTextView")]) {
     NSTextStorage *textStorage = [FBSDKAppEventsUtility getVariable:@"_textStorage"
                                                        fromInstance:obj];
     if (textStorage) {
-      text = textStorage.string;
+      text = [textStorage string];
     }
   } else if ([obj isKindOfClass:objc_lookUpClass("RCTBaseTextInputView")]) {
     NSAttributedString *attributedText = [FBSDKAppEventsUtility getVariable:@"attributedText"
                                                                fromInstance:obj];
-    text = attributedText.string;
+    text = [attributedText string];
   }
 
   if ([obj conformsToProtocol:@protocol(UITextInput)]) {
     id<UITextInput> input = (id<UITextInput>)obj;
-    if (input.secureTextEntry) {
+    if ([input isSecureTextEntry]) {
       text = nil;
     } else {
       switch (input.keyboardType) {
@@ -386,10 +393,6 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
         default: break;
       }
     }
-  }
-
-  if ([FBSDKAppEventsUtility isSensitiveUserData:text]) {
-    return nil;
   }
 
   return text.length > 0 ? text : nil;
@@ -429,9 +432,9 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
   NSString *hint = nil;
 
   if ([obj isKindOfClass:[UITextField class]]) {
-    hint = ((UITextField *)obj).placeholder;
+    hint = [(UITextField *)obj placeholder];
   } else if ([obj isKindOfClass:[UINavigationController class]]) {
-    UIViewController *top = ((UINavigationController *)obj).topViewController;
+    UIViewController *top = [(UINavigationController *)obj topViewController];
     if (top) {
       hint = NSStringFromClass([top class]);
     }
@@ -464,8 +467,12 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
       bitmask |= FBCodelessClassBitmaskLabel;
     }
 
-    if ([FBSDKViewHierarchy isRCTButton:((UIView *)obj)]) {
-      bitmask |= FBCodelessClassBitmaskReactNativeButton;
+    if ([(UIView *)obj isAccessibilityElement] &&
+        [(UIView *)obj accessibilityTraits] == UIAccessibilityTraitButton) {
+      Class classRCTView = objc_lookUpClass(ReactNativeClassRCTView);
+      if (classRCTView && [obj isKindOfClass:classRCTView]) {
+        bitmask |= FBCodelessClassBitmaskReactNativeButton;
+      }
     }
 
     // Check selector of UITextInput protocol instead of checking conformsToProtocol
@@ -479,45 +486,6 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
   return bitmask;
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundeclared-selector"
-+ (BOOL)isRCTButton:(UIView *)view
-{
-  if (view == nil) {
-    return NO;
-  }
-
-  Class classRCTView = objc_lookUpClass(ReactNativeClassRCTView);
-  if (classRCTView && [view isKindOfClass:classRCTView] &&
-      [view respondsToSelector:@selector(reactTagAtPoint:)] &&
-      [view respondsToSelector:@selector(reactTag)] &&
-      view.userInteractionEnabled) {
-    NSNumber *reactTag = [view performSelector:@selector(reactTagAtPoint:)
-                                    withObject:[NSValue valueWithCGPoint:view.frame.origin]];
-    // We get the reactTag at upper left of the view and thus check with its first subview
-    UIView *subView = view.subviews.firstObject;
-    NSNumber *subViewReactTag = [FBSDKViewHierarchy getViewReactTag:subView];
-    if (reactTag != nil && subViewReactTag != nil && ![subView isKindOfClass:classRCTView] && [reactTag isEqualToNumber:subViewReactTag]) {
-      return YES;
-    }
-  }
-
-  return NO;
-}
-
-+ (NSNumber *)getViewReactTag:(UIView *)view
-{
-  if (view != nil && [view respondsToSelector:@selector(reactTag)]) {
-    NSNumber *reactTag = [view performSelector:@selector(reactTag)];
-    if (reactTag != nil && [reactTag isKindOfClass:[NSNumber class]]) {
-      return reactTag;
-    }
-  }
-
-  return nil;
-}
-#pragma clang diagnostic pop
-
 + (BOOL)isView:(NSObject *)obj1 superViewOfView:(UIView *)obj2
 {
   if (![obj1 isKindOfClass:[UIView class]]
@@ -528,7 +496,7 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
   UIView *view2 = (UIView *)obj2;
   UIView *superview = view2;
   while (superview) {
-    superview = superview.superview;
+    superview = [superview superview];
     if (superview == view1) {
       return YES;
     }
@@ -542,7 +510,7 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
   UIResponder *parentResponder = view;
 
   while (parentResponder) {
-    parentResponder = parentResponder.nextResponder;
+    parentResponder = [parentResponder nextResponder];
     if ([parentResponder isKindOfClass:[UIViewController class]]) {
       return (UIViewController *)parentResponder;
     }
@@ -558,7 +526,7 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
     if ([superview isKindOfClass:[UITableView class]]) {
       return (UITableView *)superview;
     }
-    superview = superview.superview;
+    superview = [superview superview];
   }
   return nil;
 }
@@ -570,7 +538,7 @@ typedef NS_ENUM(NSUInteger, FBCodelessClassBitmask) {
     if ([superview isKindOfClass:[UICollectionView class]]) {
       return (UICollectionView *)superview;
     }
-    superview = superview.superview;
+    superview = [superview superview];
   }
   return nil;
 }

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKAppEventsDeviceInfo.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKAppEventsDeviceInfo.m
@@ -147,7 +147,7 @@ static const u_int FB_GIGABYTE = 1024 * 1024 * 1024;  // bytes
   _shortVersion = [mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
 
   // Locale stuff
-  _language = [NSLocale currentLocale].localeIdentifier;
+  _language = [[NSLocale currentLocale] localeIdentifier];
 
   // Device stuff
   UIDevice *device = [UIDevice currentDevice];
@@ -165,7 +165,7 @@ static const u_int FB_GIGABYTE = 1024 * 1024 * 1024;  // bytes
   _machine = @(systemInfo.machine);
 
   // Disk space stuff
-  float totalDiskSpace = [FBSDKAppEventsDeviceInfo _getTotalDiskSpace].floatValue;
+  float totalDiskSpace = [[FBSDKAppEventsDeviceInfo _getTotalDiskSpace] floatValue];
   _totalDiskSpaceGB = (unsigned long long)round(totalDiskSpace / FB_GIGABYTE);
 }
 
@@ -194,7 +194,7 @@ static const u_int FB_GIGABYTE = 1024 * 1024 * 1024;  // bytes
   }
 
   // Remaining disk space
-  float remainingDiskSpace = [FBSDKAppEventsDeviceInfo _getRemainingDiskSpace].floatValue;
+  float remainingDiskSpace = [[FBSDKAppEventsDeviceInfo _getRemainingDiskSpace] floatValue];
   unsigned long long newRemainingDiskSpaceGB = (unsigned long long)round(remainingDiskSpace / FB_GIGABYTE);
   if (_remainingDiskSpaceGB != newRemainingDiskSpaceGB) {
     _remainingDiskSpaceGB = newRemainingDiskSpaceGB;
@@ -237,14 +237,14 @@ static const u_int FB_GIGABYTE = 1024 * 1024 * 1024;  // bytes
 {
   NSDictionary *attrs = [[[NSFileManager alloc] init] attributesOfFileSystemForPath:NSHomeDirectory()
                                                                               error:nil];
-  return attrs[NSFileSystemSize];
+  return [attrs objectForKey:NSFileSystemSize];
 }
 
 + (NSNumber *)_getRemainingDiskSpace
 {
   NSDictionary *attrs = [[[NSFileManager alloc] init] attributesOfFileSystemForPath:NSHomeDirectory()
                                                                               error:nil];
-  return attrs[NSFileSystemFreeSize];
+  return [attrs objectForKey:NSFileSystemFreeSize];
 }
 
 + (uint)_coreCount
@@ -270,8 +270,8 @@ static const u_int FB_GIGABYTE = 1024 * 1024 * 1024;  // bytes
 #else
   // Dynamically load class for this so calling app doesn't need to link framework in.
   CTTelephonyNetworkInfo *networkInfo = [[fbsdkdfl_CTTelephonyNetworkInfoClass() alloc] init];
-  CTCarrier *carrier = networkInfo.subscriberCellularProvider;
-  return carrier.carrierName ?: @"NoCarrier";
+  CTCarrier *carrier = [networkInfo subscriberCellularProvider];
+  return [carrier carrierName] ?: @"NoCarrier";
 #endif
 }
 

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKAppEventsState.h
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKAppEventsState.h
@@ -21,11 +21,10 @@
 // this type is not thread safe.
 @interface FBSDKAppEventsState : NSObject<NSCopying, NSSecureCoding>
 
-@property (nonatomic, readonly, copy) NSArray *events;
-@property (nonatomic, readonly, assign) NSUInteger numSkipped;
-@property (nonatomic, readonly, copy) NSString *tokenString;
-@property (nonatomic, readonly, copy) NSString *appID;
-@property (nonatomic, readonly) BOOL areAllEventsImplicit;
+@property (readonly, copy) NSArray *events;
+@property (readonly, assign) NSUInteger numSkipped;
+@property (readonly, copy) NSString *tokenString;
+@property (readonly, copy) NSString *appID;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
@@ -33,6 +32,7 @@
 
 - (void)addEvent:(NSDictionary *)eventDictionary isImplicit:(BOOL)isImplicit;
 - (void)addEventsFromAppEventState:(FBSDKAppEventsState *)appEventsState;
+- (BOOL)areAllEventsImplicit;
 - (BOOL)isCompatibleWithAppEventsState:(FBSDKAppEventsState *)appEventsState;
 - (BOOL)isCompatibleWithTokenString:(NSString *)tokenString appID:(NSString *)appID;
 - (NSString *)JSONStringForEvents:(BOOL)includeImplicitEvents;

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKAppEventsUtility.h
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKAppEventsUtility.h
@@ -59,6 +59,5 @@ typedef NS_ENUM(NSUInteger, FBSDKAppEventsFlushReason)
 + (id)getVariable:(NSString *)variableName fromInstance:(NSObject *)instance;
 + (NSNumber *)getNumberValue:(NSString *)text;
 + (BOOL)isDebugBuild;
-+ (BOOL)isSensitiveUserData:(NSString *)text;
 
 @end

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKAppEventsUtility.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKAppEventsUtility.m
@@ -60,10 +60,10 @@
   FBSDKAdvertisingTrackingStatus advertisingTrackingStatus = [[self class] advertisingTrackingStatus];
   if (advertisingTrackingStatus != FBSDKAdvertisingTrackingUnspecified) {
     BOOL allowed = (advertisingTrackingStatus == FBSDKAdvertisingTrackingAllowed);
-    parameters[@"advertiser_tracking_enabled"] = @(allowed).stringValue;
+    parameters[@"advertiser_tracking_enabled"] = [@(allowed) stringValue];
   }
 
-  parameters[@"application_tracking_enabled"] = @(!FBSDKSettings.limitEventAndDataUsage).stringValue;
+  parameters[@"application_tracking_enabled"] = [@(!FBSDKSettings.limitEventAndDataUsage) stringValue];
 
   NSString *userID = [FBSDKAppEvents userID];
   if (userID) {
@@ -82,8 +82,8 @@
   dispatch_once(&fetchBundleOnce, ^{
     NSBundle *mainBundle = [NSBundle mainBundle];
     urlSchemes = [[NSMutableArray alloc] init];
-    for (NSDictionary<NSString *, id> *fields in [mainBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]) {
-      NSArray<NSString *> *schemesForType = fields[@"CFBundleURLSchemes"];
+    for (NSDictionary *fields in [mainBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]) {
+      NSArray *schemesForType = [fields objectForKey:@"CFBundleURLSchemes"];
       if (schemesForType) {
         [urlSchemes addObjectsFromArray:schemesForType];
       }
@@ -91,7 +91,8 @@
   });
 
   if (urlSchemes.count > 0) {
-    parameters[@"url_schemes"] = [FBSDKInternalUtility JSONStringForObject:urlSchemes error:NULL invalidObjectHandler:NULL];
+    [parameters setObject:[FBSDKInternalUtility JSONStringForObject:urlSchemes error:NULL invalidObjectHandler:NULL]
+                   forKey:@"url_schemes"];
   }
 
   return parameters;
@@ -99,16 +100,12 @@
 
 + (NSString *)advertiserID
 {
-  if (![[FBSDKSettings advertiserIDCollectionEnabled] boolValue]) {
-    return nil;
-  }
-
   NSString *result = nil;
 
   Class ASIdentifierManagerClass = fbsdkdfl_ASIdentifierManagerClass();
   if ([ASIdentifierManagerClass class]) {
     ASIdentifierManager *manager = [ASIdentifierManagerClass sharedManager];
-    result = manager.advertisingIdentifier.UUIDString;
+    result = [[manager advertisingIdentifier] UUIDString];
   }
 
   return result;
@@ -125,7 +122,7 @@
     if ([ASIdentifierManagerClass class]) {
       ASIdentifierManager *manager = [ASIdentifierManagerClass sharedManager];
       if (manager) {
-        status = manager.advertisingTrackingEnabled ? FBSDKAdvertisingTrackingAllowed : FBSDKAdvertisingTrackingDisallowed;
+        status = [manager isAdvertisingTrackingEnabled] ? FBSDKAdvertisingTrackingAllowed : FBSDKAdvertisingTrackingDisallowed;
       }
     }
   });
@@ -142,7 +139,7 @@
     // Generate a new anonymous ID.  Create as a UUID, but then prepend the fairly
     // arbitrary 'XZ' to the front so it's easily distinguishable from IDFA's which
     // will only contain hex.
-    result = [NSString stringWithFormat:@"XZ%@", [NSUUID UUID].UUIDString];
+    result = [NSString stringWithFormat:@"XZ%@", [[NSUUID UUID] UUIDString]];
 
     [self persistAnonymousID:result];
   }
@@ -154,7 +151,7 @@
 #if TARGET_OS_TV
   return nil;
 #else
-  return [UIPasteboard pasteboardWithName:@"fb_app_attribution" create:NO].string;
+  return [[UIPasteboard pasteboardWithName:@"fb_app_attribution" create:NO] string];
 #endif
 }
 
@@ -301,7 +298,7 @@ restOfStringCharacterSet:(NSCharacterSet *)restOfStringCharacterSet
 {
   NSSearchPathDirectory directory = NSLibraryDirectory;
   NSArray *paths = NSSearchPathForDirectoriesInDomains(directory, NSUserDomainMask, YES);
-  NSString *docDirectory = paths[0];
+  NSString *docDirectory = [paths objectAtIndex:0];
   return [docDirectory stringByAppendingPathComponent:filename];
 }
 
@@ -313,7 +310,7 @@ restOfStringCharacterSet:(NSCharacterSet *)restOfStringCharacterSet
                                                       encoding:NSASCIIStringEncoding
                                                          error:nil];
   NSDictionary *results = [FBSDKInternalUtility objectForJSONString:content error:NULL];
-  return results[FBSDK_APPEVENTSUTILITY_ANONYMOUSID_KEY];
+  return [results objectForKey:FBSDK_APPEVENTSUTILITY_ANONYMOUSID_KEY];
 }
 
 // Given a candidate token (which may be nil), find the real token to string to use.
@@ -341,11 +338,11 @@ restOfStringCharacterSet:(NSCharacterSet *)restOfStringCharacterSet
 
 + (long)unixTimeNow
 {
-  return (long)round([NSDate date].timeIntervalSince1970);
+  return (long)round([[NSDate date] timeIntervalSince1970]);
 }
 
 + (id)getVariable:(NSString *)variableName fromInstance:(NSObject *)instance {
-  Ivar ivar = class_getInstanceVariable([instance class], variableName.UTF8String);
+  Ivar ivar = class_getInstanceVariable([instance class], [variableName UTF8String]);
   if (ivar != NULL) {
     const char *encoding = ivar_getTypeEncoding(ivar);
     if (encoding != NULL && encoding[0] == '@') {
@@ -380,7 +377,7 @@ restOfStringCharacterSet:(NSCharacterSet *)restOfStringCharacterSet
 
     value = [formatter numberFromString:validText];
     if (nil == value) {
-      value = @(validText.floatValue);
+      value = @([validText floatValue]);
     }
   }
 
@@ -417,58 +414,6 @@ restOfStringCharacterSet:(NSCharacterSet *)restOfStringCharacterSet
 
   return NO;
 #endif
-}
-
-+ (BOOL)isSensitiveUserData:(NSString *)text
-{
-  if (0 == text.length) {
-    return NO;
-  }
-
-  return [self isEmailAddress:text] || [self isCreditCardNumber:text];
-}
-
-+ (BOOL)isCreditCardNumber:(NSString *)text
-{
-  text = [[text componentsSeparatedByCharactersInSet:[NSCharacterSet.decimalDigitCharacterSet invertedSet]] componentsJoinedByString:@""];
-
-  if (text.doubleValue == 0) {
-    return NO;
-  }
-
-  if (text.length < 9 || text.length > 21) {
-    return NO;
-  }
-
-  const char *chars = [text cStringUsingEncoding:NSUTF8StringEncoding];
-  if (NULL == chars) {
-    return NO;
-  }
-
-  BOOL isOdd = YES;
-  int oddSum = 0;
-  int evenSum = 0;
-
-  for (int i = (int)text.length - 1; i >= 0; i--) {
-    int digit = chars[i] - '0';
-
-    if (isOdd)
-      oddSum += digit;
-    else
-      evenSum += digit / 5 + (2 * digit) % 10;
-
-    isOdd = !isOdd;
-  }
-
-  return ((oddSum + evenSum) % 10 == 0);
-}
-
-+ (BOOL)isEmailAddress:(NSString *)text
-{
-  NSString *pattern = @"[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}";
-  NSRegularExpression *regex = [[NSRegularExpression alloc] initWithPattern:pattern options:NSRegularExpressionCaseInsensitive error:nil];
-  NSUInteger matches = [regex numberOfMatchesInString:text options:0 range:NSMakeRange(0, [text length])];
-  return matches > 0;
 }
 
 @end

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKHybridAppEventsScriptMessageHandler.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKHybridAppEventsScriptMessageHandler.m
@@ -32,7 +32,7 @@ NSString *const FBSDKAppEventsWKWebViewMessagesPixelReferralParamKey = @"_fb_pix
 
   if ([message.name isEqualToString:FBSDKAppEventsWKWebViewMessagesHandlerKey]) {
     NSString *event = message.body[FBSDKAppEventsWKWebViewMessagesEventKey];
-    if (event.length > 0) {
+    if ([event length] > 0) {
       NSString *stringedParams = message.body[FBSDKAppEventsWKWebViewMessagesParamsKey];
       NSMutableDictionary <NSObject *, NSObject *> *params = nil;
       NSError *jsonParseError = nil;
@@ -52,7 +52,7 @@ NSString *const FBSDKAppEventsWKWebViewMessagesPixelReferralParamKey = @"_fb_pix
         params = [[NSMutableDictionary alloc] initWithObjectsAndKeys:pixelID, FBSDKAppEventsWKWebViewMessagesPixelReferralParamKey, nil];
       }
       else {
-        params[FBSDKAppEventsWKWebViewMessagesPixelReferralParamKey] = pixelID;
+        [params setObject:pixelID forKey: FBSDKAppEventsWKWebViewMessagesPixelReferralParamKey];
       }
       [FBSDKAppEvents logEvent:event parameters:params];
     }

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKPaymentObserver.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKPaymentObserver.m
@@ -22,6 +22,7 @@
 
 #import "FBSDKAppEvents+Internal.h"
 #import "FBSDKDynamicFrameworkLoader.h"
+#import "FBSDKGateKeeperManager.h"
 #import "FBSDKLogger.h"
 #import "FBSDKSettings.h"
 
@@ -185,7 +186,7 @@ static NSMutableArray *g_pendingRequestors;
     return @"";
   }
 
-  return inputString.length <= FBSDKMaxParameterValueLength ? inputString : [inputString substringToIndex:FBSDKMaxParameterValueLength];
+  return [inputString length] <= FBSDKMaxParameterValueLength ? inputString : [inputString substringToIndex:FBSDKMaxParameterValueLength];
 }
 
 - (void)logTransactionEvent:(SKProduct *)product
@@ -194,7 +195,7 @@ static NSMutableArray *g_pendingRequestors;
   NSString *transactionID = nil;
   NSString *transactionDate = nil;
   NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-  formatter.dateFormat = @"yyyy-MM-dd HH:mm:ssZ";
+  [formatter setDateFormat:@"yyyy-MM-dd HH:mm:ssZ"];
   switch (self.transaction.transactionState) {
     case SKPaymentTransactionStatePurchasing:
       eventName = FBSDKAppEventNameInitiatedCheckout;
@@ -240,6 +241,9 @@ static NSMutableArray *g_pendingRequestors;
     if (@available(iOS 11.2, *)) {
       BOOL isSubscription = (product.subscriptionPeriod != nil) && ((unsigned long)product.subscriptionPeriod.numberOfUnits > 0);
       if (isSubscription) {
+        if ([FBSDKGateKeeperManager boolForKey:@"app_events_if_auto_log_subs" appID:[FBSDKSettings appID] defaultValue:true]) {
+          eventName = FBSDKAppEventNameSubscribe;
+        }
         // subs inapp
         SKProductSubscriptionPeriod *period = product.subscriptionPeriod;
         NSString *unit = nil;
@@ -250,16 +254,16 @@ static NSMutableArray *g_pendingRequestors;
           case SKProductPeriodUnitYear: unit = @"Y"; break;
         }
         NSString *p = [NSString stringWithFormat:@"P%lu%@", (unsigned long)period.numberOfUnits, unit];
-        eventParameters[FBSDKAppEventParameterNameSubscriptionPeriod] = p;
-        eventParameters[FBSDKAppEventParameterNameInAppPurchaseType] = @"subs";
+        [eventParameters setObject:p forKey:FBSDKAppEventParameterNameSubscriptionPeriod];
+        [eventParameters setObject:@"subs" forKey:FBSDKAppEventParameterNameInAppPurchaseType];
       } else {
-        eventParameters[FBSDKAppEventParameterNameInAppPurchaseType] = @"inapp";
+        [eventParameters setObject:@"inapp" forKey:FBSDKAppEventParameterNameInAppPurchaseType];
       }
     }
 #endif
 #endif
     if (transactionID) {
-      eventParameters[FBSDKAppEventParameterNameTransactionID] = transactionID;
+      [eventParameters setObject:transactionID forKey:FBSDKAppEventParameterNameTransactionID];
     }
   }
 
@@ -314,7 +318,7 @@ static NSMutableArray *g_pendingRequestors;
     }
   }
 
-  eventParameters[FBSDKAppEventParameterImplicitlyLoggedPurchase] = @"1";
+  [eventParameters setObject:@"1" forKey:FBSDKAppEventParameterImplicitlyLoggedPurchase];
   [FBSDKAppEvents logEvent:eventName
                 valueToSum:valueToSum
                 parameters:eventParameters];
@@ -328,7 +332,7 @@ static NSMutableArray *g_pendingRequestors;
 
 // Fetch the current receipt for this application.
 - (NSData*)fetchDeviceReceipt {
-  NSURL *receiptURL = [NSBundle bundleForClass:[self class]].appStoreReceiptURL;
+  NSURL *receiptURL = [[NSBundle bundleForClass:[self class]] appStoreReceiptURL];
   NSData *receipt = [NSData dataWithContentsOfURL:receiptURL];
   return receipt;
 }

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKTimeSpentData.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKTimeSpentData.m
@@ -192,7 +192,7 @@ static const long INACTIVE_SECONDS_QUANTA[] =
     if (!content) {
 
       // Nothing persisted, so this is the first launch.
-      _sessionID = [NSUUID UUID].UUIDString;
+      _sessionID = [[NSUUID UUID] UUIDString];
       _secondsSpentInCurrentSession = 0;
       _numInterruptionsInCurrentSession = 0;
       _lastSuspendTime = 0;
@@ -205,12 +205,12 @@ static const long INACTIVE_SECONDS_QUANTA[] =
 
       NSDictionary *results = [FBSDKInternalUtility objectForJSONString:content error:NULL];
 
-      _lastSuspendTime = [results[FBSDKTimeSpentPersistKeyLastSuspendTime] longValue];
+      _lastSuspendTime = [[results objectForKey:FBSDKTimeSpentPersistKeyLastSuspendTime] longValue];
 
       _timeSinceLastSuspend = now - _lastSuspendTime;
-      _secondsSpentInCurrentSession = [results[FBSDKTimeSpentPersistKeySessionSecondsSpent] intValue];
-      _sessionID = results[FBSDKTimeSpentPersistKeySessionID] ? : [NSUUID UUID].UUIDString;
-      _numInterruptionsInCurrentSession = [results[FBSDKTimeSpentPersistKeySessionNumInterruptions] intValue];
+      _secondsSpentInCurrentSession = [[results objectForKey:FBSDKTimeSpentPersistKeySessionSecondsSpent] intValue];
+      _sessionID = results[FBSDKTimeSpentPersistKeySessionID] ? : [[NSUUID UUID] UUIDString];
+      _numInterruptionsInCurrentSession = [[results objectForKey:FBSDKTimeSpentPersistKeySessionNumInterruptions] intValue];
       _shouldLogActivateEvent = (_timeSinceLastSuspend > [FBSDKServerConfigurationManager cachedServerConfiguration].sessionTimoutInterval);
 
       // Other than the first launch, we always log the last session's deactivate with this session's activate.
@@ -237,7 +237,7 @@ static const long INACTIVE_SECONDS_QUANTA[] =
         // We've logged the session stats, now reset.
         _secondsSpentInCurrentSession = 0;
         _numInterruptionsInCurrentSession = 0;
-        _sessionID = [NSUUID UUID].UUIDString;
+        _sessionID = [[NSUUID UUID] UUIDString];
       }
 
       if (_shouldLogActivateEvent) {

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKUserDataStore.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKUserDataStore.m
@@ -143,7 +143,7 @@ static volatile bool initialized = false;
     return nil;
   }
 
-  NSMutableDictionary<NSString *, id> *encryptUserData = [NSMutableDictionary dictionaryWithCapacity:ud.count];
+  NSMutableDictionary *encryptUserData = [NSMutableDictionary dictionaryWithCapacity:[ud count]];
 
   for (NSString *key in ud){
     NSString *const value = ud[key];
@@ -173,7 +173,7 @@ static volatile bool initialized = false;
 
 + (NSString *)encryptData:(NSString *)data
 {
-  if (data == nil || data.length == 0){
+  if (data == nil || [data length] == 0){
     return nil;
   }
   return [FBSDKUtility SHA256Hash:data];
@@ -185,7 +185,7 @@ static volatile bool initialized = false;
       || [type isEqualToString:FBSDKLastName] || [type isEqualToString:FBSDKCity]
       || [type isEqualToString:FBSDKState] || [type isEqualToString:FBSDKCountry]) {
     normalizedData = [data stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-    normalizedData = normalizedData.lowercaseString;
+    normalizedData = [normalizedData lowercaseString];
   } else if ([type isEqualToString:FBSDKPhone]){
     NSError *error = nil;
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"[^0-9]"
@@ -194,13 +194,13 @@ static volatile bool initialized = false;
                                   ];
     normalizedData = [regex stringByReplacingMatchesInString:data
                                                      options:0
-                                                       range:NSMakeRange(0, data.length)
+                                                       range:NSMakeRange(0, [data length])
                                                 withTemplate:@""
                       ];
   } else if ([type isEqualToString:FBSDKGender]){
     NSString *temp = [data stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-    temp = temp.lowercaseString;
-    normalizedData = temp.length > 0 ? [temp substringToIndex:1]: @"";
+    temp = [temp lowercaseString];
+    normalizedData = [temp length] > 0 ? [temp substringToIndex:1]: @"";
   }
 
   return normalizedData;
@@ -209,7 +209,7 @@ static volatile bool initialized = false;
 + (BOOL)maybeSHA256Hashed:(NSString *)data
 {
   NSRange range = [data rangeOfString:@"[A-Fa-f0-9]{64}" options:NSRegularExpressionSearch];
-  return (data.length == 64) && (range.location != NSNotFound);
+  return ([data length] == 64) && (range.location != NSNotFound);
 }
 
 @end

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/FBSDKBoltsMeasurementEventListener.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/AppLink/FBSDKBoltsMeasurementEventListener.m
@@ -68,7 +68,7 @@ static NSString *const BoltsMeasurementEventPrefix = @"bf_";
         NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"[^0-9a-zA-Z _-]" options:0 error:&error];
         NSString *safeKey = [regex stringByReplacingMatchesInString:key
                                                             options:0
-                                                              range:NSMakeRange(0, key.length)
+                                                              range:NSMakeRange(0, [key length])
                                                        withTemplate:@"-"];
         safeKey = [safeKey stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@" -"]];
         logData[safeKey] = eventArgs[key];

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPICrypto.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPICrypto.m
@@ -65,7 +65,7 @@ static NSString *g_cipherKey = nil;
     return nil;
   }
   NSArray *additionalSignedDataArray = @[
-                                         [NSBundle mainBundle].bundleIdentifier,
+                                         [[NSBundle mainBundle] bundleIdentifier],
                                          [FBSDKSettings appID] ?: @"",
                                          @"bridge",
                                          request.methodName ?: @"",

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPIRequest.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPIRequest.m
@@ -93,7 +93,7 @@ NSString *const FBSDKBridgeAPIVersionKey = @"version";
     _parameters = [parameters copy];
     _userInfo = [userInfo copy];
 
-    _actionID = [NSUUID UUID].UUIDString;
+    _actionID = [[NSUUID UUID] UUIDString];
   }
   return self;
 }

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/ProtocolVersions/FBSDKBridgeAPIProtocolNativeV1.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/ProtocolVersions/FBSDKBridgeAPIProtocolNativeV1.m
@@ -132,33 +132,28 @@ static const struct
                        parameters:(NSDictionary *)parameters
                             error:(NSError *__autoreleasing *)errorRef
 {
-  NSString *const host = @"dialog";
-  NSString *const path = [@"/" stringByAppendingString:methodName];
+  NSString *host = @"dialog";
+  NSString *path = [@"/" stringByAppendingString:methodName];
 
-  NSMutableDictionary<NSString *, id> *const queryParameters = [[NSMutableDictionary alloc] init];
+  NSMutableDictionary *queryParameters = [[NSMutableDictionary alloc] init];
   [FBSDKInternalUtility dictionary:queryParameters setObject:methodVersion
                             forKey:FBSDKBridgeAPIProtocolNativeV1OutputKeys.methodVersion];
 
-  if (parameters.count) {
-    NSString *const parametersString = [self _JSONStringForObject:parameters enablePasteboard:YES error:errorRef];
+  if ([parameters count]) {
+    NSString *parametersString = [self _JSONStringForObject:parameters enablePasteboard:YES error:errorRef];
     if (!parametersString) {
       return nil;
     }
-    NSString *const escapedParametersString = [parametersString stringByReplacingOccurrencesOfString:@"&"
-                                                                                          withString:@"%26"
-                                                                                             options:NSCaseInsensitiveSearch
-                                                                                               range:NSMakeRange(0,
-                                                                                                                 parametersString.length)];
     [FBSDKInternalUtility dictionary:queryParameters
-                           setObject:escapedParametersString
+                           setObject:parametersString
                               forKey:FBSDKBridgeAPIProtocolNativeV1OutputKeys.methodArgs];
   }
 
-  NSDictionary<NSString *, id> *const bridgeParameters = [self _bridgeParametersWithActionID:actionID error:errorRef];
+  NSDictionary *bridgeParameters = [self _bridgeParametersWithActionID:actionID error:errorRef];
   if (!bridgeParameters) {
     return nil;
   }
-  NSString *const bridgeParametersString = [self _JSONStringForObject:bridgeParameters enablePasteboard:NO error:errorRef];
+  NSString *bridgeParametersString = [self _JSONStringForObject:bridgeParameters enablePasteboard:NO error:errorRef];
   if (!bridgeParametersString) {
     return nil;
   }
@@ -240,7 +235,7 @@ static const struct
   NSArray *files = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIcons"]
   [@"CFBundlePrimaryIcon"]
   [@"CFBundleIconFiles"];
-  if (!files.count) {
+  if (![files count]) {
     return nil;
   }
   return [UIImage imageNamed:files[0]];
@@ -312,7 +307,7 @@ static const struct
       }
       return dictionary;
     } else if ([invalidObject isKindOfClass:[NSURL class]]) {
-      return ((NSURL *)invalidObject).absoluteString;
+      return [(NSURL *)invalidObject absoluteString];
     }
     return invalidObject;
   }];

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/ProtocolVersions/FBSDKBridgeAPIProtocolWebV2.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/ProtocolVersions/FBSDKBridgeAPIProtocolWebV2.m
@@ -98,7 +98,7 @@
   }
 
   NSMutableDictionary *queryParameters = [[FBSDKUtility dictionaryWithQueryString:requestURL.query] mutableCopy];
-  queryParameters[@"ios_bundle_id"] = [NSBundle mainBundle].bundleIdentifier;
+  queryParameters[@"ios_bundle_id"] = [[NSBundle mainBundle] bundleIdentifier];
   NSURL *redirectURL = [self _redirectURLWithActionID:nil methodName:methodName error:errorRef];
   if (!redirectURL) {
     return nil;

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/FBSDKCrypto.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/Cryptography/FBSDKCrypto.m
@@ -78,7 +78,7 @@ static inline NSData *FBSDKCryptoMakeSubKey(uint8_t *key, size_t len, uint32_t i
   NSData *masterKeyData = [FBSDKCrypto randomBytes:kFBSDK_CRYPTO_CURRENT_MASTER_KEY_LENGTH + 1];
 
   // force the first byte to be the crypto version
-  uint8_t *first = (uint8_t *)masterKeyData.bytes;
+  uint8_t *first = (uint8_t *) [masterKeyData bytes];
   *first = kFBSDK_CRYPTO_CURRENT_VERSION;
 
   NSString *masterKey = [FBSDKBase64 encodeData:masterKeyData];
@@ -111,8 +111,8 @@ static inline NSData *FBSDKCryptoMakeSubKey(uint8_t *key, size_t len, uint32_t i
 {
   if ((self = [super init])) {
     NSData *masterKeyData = [FBSDKBase64 decodeAsData:masterKey];
-    NSUInteger len = masterKeyData.length;
-    uint8_t *first = (uint8_t *)masterKeyData.bytes;
+    NSUInteger len = [masterKeyData length];
+    uint8_t *first = (uint8_t *) [masterKeyData bytes];
 
     if (len == 0 || first == nil || *first != kFBSDK_CRYPTO_CURRENT_VERSION) {
       // only one version supported at the moment

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKAudioResourceLoader.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKAudioResourceLoader.m
@@ -79,7 +79,7 @@
 {
   NSURL *fileURL = [self _fileURL:errorRef];
 
-  if (![_fileManager fileExistsAtPath:fileURL.path]) {
+  if (![_fileManager fileExistsAtPath:[fileURL path]]) {
     NSData *data = [[self class] data];
     if (![data writeToURL:fileURL options:NSDataWritingAtomic error:errorRef]) {
       return NO;

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKDeviceRequestsHelper.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKDeviceRequestsHelper.m
@@ -54,8 +54,9 @@ static NSMapTable *g_mdnsAdvertisementServices;
   struct utsname systemInfo;
   uname(&systemInfo);
   NSDictionary *deviceInfo = @{
-                               FBSDK_DEVICE_INFO_DEVICE: @(systemInfo.machine),
-                               FBSDK_DEVICE_INFO_MODEL: [UIDevice currentDevice].model,
+                               FBSDK_DEVICE_INFO_DEVICE: [NSString stringWithCString:systemInfo.machine
+                                                                            encoding:NSUTF8StringEncoding],
+                               FBSDK_DEVICE_INFO_MODEL: [[UIDevice currentDevice] model],
                                };
   NSError *err;
   NSData *jsonDeviceInfo = [NSJSONSerialization dataWithJSONObject:deviceInfo

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKError.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKError.m
@@ -91,7 +91,7 @@
   NSMutableDictionary *fullUserInfo = [[NSMutableDictionary alloc] initWithDictionary:userInfo];
   [FBSDKInternalUtility dictionary:fullUserInfo setObject:message forKey:FBSDKErrorDeveloperMessageKey];
   [FBSDKInternalUtility dictionary:fullUserInfo setObject:underlyingError forKey:NSUnderlyingErrorKey];
-  userInfo = fullUserInfo.count ? [fullUserInfo copy] : nil;
+  userInfo = ([fullUserInfo count] ? [fullUserInfo copy] : nil);
   return [[NSError alloc] initWithDomain:domain code:code userInfo:userInfo];
 }
 

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
@@ -103,9 +103,9 @@ typedef NS_ENUM(NSUInteger, FBSDKInternalUtilityVersionShift)
 + (id)convertRequestValue:(id)value
 {
   if ([value isKindOfClass:[NSNumber class]]) {
-    value = ((NSNumber *)value).stringValue;
+    value = [(NSNumber *)value stringValue];
   } else if ([value isKindOfClass:[NSURL class]]) {
-    value = ((NSURL *)value).absoluteString;
+    value = [(NSURL *)value absoluteString];
   }
   return value;
 }
@@ -136,7 +136,7 @@ setJSONStringForObject:(id)object
 + (void)dictionary:(NSMutableDictionary *)dictionary setObject:(id)object forKey:(id<NSCopying>)key
 {
   if (object && key) {
-    dictionary[key] = object;
+    [dictionary setObject:object forKey:key];
   }
 }
 
@@ -177,23 +177,23 @@ setJSONStringForObject:(id)object
                       defaultVersion:(NSString *)defaultVersion
                                error:(NSError *__autoreleasing *)errorRef
 {
-  if (hostPrefix.length && ![hostPrefix hasSuffix:@"."]) {
+  if ([hostPrefix length] && ![hostPrefix hasSuffix:@"."]) {
     hostPrefix = [hostPrefix stringByAppendingString:@"."];
   }
 
   NSString *host = @"facebook.com";
   NSString *domainPart = [FBSDKSettings facebookDomainPart];
-  if (domainPart.length) {
+  if ([domainPart length]) {
     host = [[NSString alloc] initWithFormat:@"%@.%@", domainPart, host];
   }
   host = [NSString stringWithFormat:@"%@%@", hostPrefix ?: @"", host ?: @""];
 
   NSString *version = defaultVersion ?: [FBSDKSettings graphAPIVersion];
-  if (version.length) {
+  if ([version length]) {
     version = [@"/" stringByAppendingString:version];
   }
 
-  if (path.length) {
+  if ([path length]) {
     NSScanner *versionScanner = [[NSScanner alloc] initWithString:path];
     if ([versionScanner scanString:@"/v" intoString:NULL] &&
         [versionScanner scanInteger:NULL] &&
@@ -220,7 +220,7 @@ setJSONStringForObject:(id)object
 
 + (BOOL)isBrowserURL:(NSURL *)URL
 {
-  NSString *scheme = URL.scheme.lowercaseString;
+  NSString *scheme = [URL.scheme lowercaseString];
   return ([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"]);
 }
 
@@ -361,7 +361,7 @@ setJSONStringForObject:(id)object
   NSMutableString *queryString = [[NSMutableString alloc] init];
   __block BOOL hasParameters = NO;
   if (dictionary) {
-    NSMutableArray<NSString *> *keys = [dictionary.allKeys mutableCopy];
+    NSMutableArray *keys = [[dictionary allKeys] mutableCopy];
     // remove non-string keys, as they are not valid
     [keys filterUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
       return [evaluatedObject isKindOfClass:[NSString class]];
@@ -392,7 +392,7 @@ setJSONStringForObject:(id)object
   if (errorRef != NULL) {
     *errorRef = nil;
   }
-  return (queryString.length ? [queryString copy] : nil);
+  return ([queryString length] ? [queryString copy] : nil);
 }
 
 + (BOOL)shouldManuallyAdjustOrientation
@@ -412,7 +412,7 @@ setJSONStringForObject:(id)object
   }
 
   NSString *queryString = nil;
-  if (queryParameters.count) {
+  if ([queryParameters count]) {
     NSError *queryStringError;
     queryString = [@"?" stringByAppendingString:[FBSDKUtility queryStringWithDictionary:queryParameters
                                                                                   error:&queryStringError]];
@@ -464,7 +464,7 @@ static NSMapTable *_transientObjects;
   if (!_transientObjects) {
     _transientObjects = [[NSMapTable alloc] init];
   }
-  NSUInteger count = ((NSNumber *)[_transientObjects objectForKey:object]).unsignedIntegerValue;
+  NSUInteger count = [(NSNumber *)[_transientObjects objectForKey:object] unsignedIntegerValue];
   [_transientObjects setObject:@(count + 1) forKey:object];
 }
 
@@ -474,7 +474,7 @@ static NSMapTable *_transientObjects;
     return;
   }
   NSAssert([NSThread isMainThread], @"Must be called from the main thread!");
-  NSUInteger count = ((NSNumber *)[_transientObjects objectForKey:object]).unsignedIntegerValue;
+  NSUInteger count = [(NSNumber *)[_transientObjects objectForKey:object] unsignedIntegerValue];
   if (count == 1) {
     [_transientObjects removeObjectForKey:object];
   } else if (count != 0) {
@@ -557,7 +557,7 @@ static NSMapTable *_transientObjects;
   if ([object isKindOfClass:[NSString class]] || [object isKindOfClass:[NSNumber class]]) {
     // good to go, keep the object
   } else if ([object isKindOfClass:[NSURL class]]) {
-    object = ((NSURL *)object).absoluteString;
+    object = [(NSURL *)object absoluteString];
   } else if ([object isKindOfClass:[NSDictionary class]]) {
     NSMutableDictionary *dictionary = [[NSMutableDictionary alloc] init];
     [(NSDictionary *)object enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *dictionaryStop) {
@@ -689,7 +689,7 @@ static NSMapTable *_transientObjects;
   static NSArray *urlTypes = nil;
 
   dispatch_once(&fetchBundleOnce, ^{
-    urlTypes = [[NSBundle mainBundle].infoDictionary valueForKey:@"CFBundleURLTypes"];
+    urlTypes = [[[NSBundle mainBundle] infoDictionary] valueForKey:@"CFBundleURLTypes"];
   });
   for (NSDictionary *urlType in urlTypes) {
     NSArray *urlSchemes = [urlType valueForKey:@"CFBundleURLSchemes"];
@@ -729,7 +729,7 @@ static NSMapTable *_transientObjects;
   static NSArray *schemes = nil;
 
   dispatch_once(&fetchBundleOnce, ^{
-    schemes = [[NSBundle mainBundle].infoDictionary valueForKey:@"LSApplicationQueriesSchemes"];
+    schemes = [[[NSBundle mainBundle] infoDictionary] valueForKey:@"LSApplicationQueriesSchemes"];
   });
 
   return [schemes containsObject:urlScheme];

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKLogger.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKLogger.m
@@ -87,7 +87,7 @@ static NSMutableDictionary *g_startTimesWithTags = nil;
 
 - (void)appendKey:(NSString *)key value:(NSString *)value
 {
-  if (_isActive && value.length) {
+  if (_isActive && [value length]) {
     [_internalContents appendFormat:@"  %@:\t%@\n", key, value];
   }
 }
@@ -98,7 +98,7 @@ static NSMutableDictionary *g_startTimesWithTags = nil;
 
     for (NSString *key in [g_stringsToReplace keyEnumerator]) {
       [_internalContents replaceOccurrencesOfString:key
-                                         withString:g_stringsToReplace[key]
+                                         withString:[g_stringsToReplace objectForKey:key]
                                             options:NSLiteralSearch
                                               range:NSMakeRange(0, _internalContents.length)];
     }
@@ -158,8 +158,8 @@ static NSMutableDictionary *g_startTimesWithTags = nil;
     // Start time of this "timestampTag" is stashed in the dictionary.
     // Treat the incoming object tag simply as an address, since it's only used to identify during lifetime.  If
     // we send in as an object, the dictionary will try to copy it.
-    NSNumber *tagAsNumber = @((unsigned long)(__bridge void *)timestampTag);
-    NSNumber *startTimeNumber = g_startTimesWithTags[tagAsNumber];
+    NSNumber *tagAsNumber = [NSNumber numberWithUnsignedLong:(unsigned long)(__bridge void *)timestampTag];
+    NSNumber *startTimeNumber = [g_startTimesWithTags objectForKey:tagAsNumber];
 
     // Only log if there's been an associated start time.
     if (startTimeNumber) {
@@ -193,7 +193,8 @@ static NSMutableDictionary *g_startTimesWithTags = nil;
     // Treat the incoming object tag simply as an address, since it's only used to identify during lifetime.  If
     // we send in as an object, the dictionary will try to copy it.
     unsigned long tagAsNumber = (unsigned long)(__bridge void *)timestampTag;
-    g_startTimesWithTags[@(tagAsNumber)] = @(currTime);
+    [g_startTimesWithTags setObject:@(currTime)
+                             forKey:[NSNumber numberWithUnsignedLong:tagAsNumber]];
   }
 }
 
@@ -203,7 +204,7 @@ static NSMutableDictionary *g_startTimesWithTags = nil;
 
   // Strings sent in here never get cleaned up, but that's OK, don't ever expect too many.
 
-  if ([FBSDKSettings loggingBehavior].count > 0) {  // otherwise there's no logging.
+  if ([[FBSDKSettings loggingBehavior] count] > 0) {  // otherwise there's no logging.
 
     if (!g_stringsToReplace) {
       g_stringsToReplace = [[NSMutableDictionary alloc] init];

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKSwizzler.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKSwizzler.m
@@ -191,9 +191,9 @@ static void (*fb_swizzledMethods[MAX_ARGS - MIN_ARGS + 1])() = {fb_swizzledMetho
             IMP swizzledMethod = (IMP)fb_swizzledMethods[numArgs - 2];
             // Check whether the first parameter is integer
             if (4 == numArgs) {
-              NSString *firstType = @(method_copyArgumentType(aMethod, 2));
+              NSString *firstType = [NSString stringWithUTF8String:method_copyArgumentType(aMethod, 2)];
               NSString *integerTypes = @"islq";
-              if ([integerTypes containsString:firstType.lowercaseString]) {
+              if ([integerTypes containsString:[firstType lowercaseString]]) {
                 swizzledMethod = (IMP)fb_swizzleMethod_4_io;
               }
             }

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKSystemAccountStoreAdapter.h
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKSystemAccountStoreAdapter.h
@@ -31,28 +31,6 @@ typedef void (^FBSDKGraphRequestAccessToAccountsHandler)(NSString *oauthToken, N
 @interface FBSDKSystemAccountStoreAdapter : NSObject
 
 /*
- s gets the oauth token stored in the account store credential, if available. If not empty,
- this implies user has granted access.
- */
-@property (nonatomic, readonly, copy) NSString *accessTokenString;
-
-/*
-  Gets or sets the flag indicating if the next requestAccess call should block
- on a renew call.
- */
-@property (nonatomic, assign) BOOL forceBlockingRenew;
-
-/*
-  A convenience getter to the Facebook account type in the account store, if available.
- */
-@property (strong, nonatomic, readonly) ACAccountType *accountType;
-
-/*
-  The singleton instance.
- */
-@property (class, nonatomic, strong) FBSDKSystemAccountStoreAdapter *sharedInstance;
-
-/*
   Requests access to the device's Facebook account for the given parameters.
  @param permissions the permissions
  @param defaultAudience the default audience
@@ -72,5 +50,32 @@ typedef void (^FBSDKGraphRequestAccessToAccountsHandler)(NSString *oauthToken, N
  @param handler the handler that is invoked on completion
  */
 - (void)renewSystemAuthorization:(void(^)(ACAccountCredentialRenewResult result, NSError *error))handler;
+
+/*
+ s gets the oauth token stored in the account store credential, if available. If not empty,
+ this implies user has granted access.
+ */
+- (NSString *)accessTokenString;
+
+/*
+  Gets the singleton instance.
+ */
++ (FBSDKSystemAccountStoreAdapter *)sharedInstance;
+
+/*
+  Sets the singleton instance, typically only for unit tests
+ */
++ (void)setSharedInstance:(FBSDKSystemAccountStoreAdapter *)instance;
+
+/*
+  Gets or sets the flag indicating if the next requestAccess call should block
+ on a renew call.
+ */
+@property (nonatomic, assign) BOOL forceBlockingRenew;
+
+/*
+  A convenience getter to the Facebook account type in the account store, if available.
+ */
+@property (strong, nonatomic, readonly) ACAccountType *accountType;
 
 @end

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKSystemAccountStoreAdapter.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKSystemAccountStoreAdapter.m
@@ -99,7 +99,7 @@ static FBSDKSystemAccountStoreAdapter *_singletonInstance = nil;
   if (self.accountType && self.accountType.accessGranted) {
     NSArray *fbAccounts = [self.accountStore accountsWithAccountType:self.accountType];
     if (fbAccounts.count > 0) {
-      id account = fbAccounts[0];
+      id account = [fbAccounts objectAtIndex:0];
       id credential = [account credential];
 
       return [credential oauthToken];
@@ -137,9 +137,11 @@ static FBSDKSystemAccountStoreAdapter *_singletonInstance = nil;
   }
 
   // construct access options
-  NSDictionary<NSString *, id> *options = @{fbsdkdfl_ACFacebookAppIdKey(): appID,
-                                            fbsdkdfl_ACFacebookPermissionsKey(): permissions.allObjects,
-                                            fbsdkdfl_ACFacebookAudienceKey(): defaultAudience};
+  NSDictionary *options = [NSDictionary dictionaryWithObjectsAndKeys:
+                           appID, fbsdkdfl_ACFacebookAppIdKey(),
+                           [permissions allObjects], fbsdkdfl_ACFacebookPermissionsKey(),
+                           defaultAudience, fbsdkdfl_ACFacebookAudienceKey(), // must end on this key/value due to audience possibly being nil
+                           nil];
 
   if (self.forceBlockingRenew
       && [self.accountStore accountsWithAccountType:self.accountType].count > 0) {
@@ -198,7 +200,7 @@ static FBSDKSystemAccountStoreAdapter *_singletonInstance = nil;
        if (granted) {
          NSArray *fbAccounts = [self.accountStore accountsWithAccountType:self.accountType];
          if (fbAccounts.count > 0) {
-           account = fbAccounts[0];
+           account = [fbAccounts objectAtIndex:0];
 
            id credential = [account credential];
 
@@ -231,11 +233,11 @@ static FBSDKSystemAccountStoreAdapter *_singletonInstance = nil;
   if (self.accountStore && self.accountType && self.accountType.accessGranted) {
     NSArray *fbAccounts = [self.accountStore accountsWithAccountType:self.accountType];
     id account;
-    if (fbAccounts && fbAccounts.count > 0 &&
-        (account = fbAccounts[0])) {
+    if (fbAccounts && [fbAccounts count] > 0 &&
+        (account = [fbAccounts objectAtIndex:0])) {
 
       FBSDKAccessToken *currentToken = [FBSDKAccessToken currentAccessToken];
-      if (![currentToken.tokenString isEqualToString:self.accessTokenString]) {
+      if (![currentToken.tokenString isEqualToString:[self accessTokenString]]) {
         currentToken = nil;
       }
       [self.accountStore renewCredentialsForAccount:account completion:^(ACAccountCredentialRenewResult renewResult, NSError *error) {
@@ -250,9 +252,8 @@ static FBSDKSystemAccountStoreAdapter *_singletonInstance = nil;
             [currentToken isEqual:[FBSDKAccessToken currentAccessToken]]) {
           // account store renewals can change the stored oauth token so we need to update the currentAccessToken
           // so future comparisons to -[ accessTokenString] work correctly (e.g., error recovery).
-          FBSDKAccessToken *updatedToken = [[FBSDKAccessToken alloc] initWithTokenString:self.accessTokenString
-                                                                             permissions:currentToken.permissions.allObjects
-                                                                     declinedPermissions:currentToken.declinedPermissions.allObjects
+          FBSDKAccessToken *updatedToken = [[FBSDKAccessToken alloc] initWithTokenString:[self accessTokenString]
+                                                                             permissions:[currentToken.permissions allObjects]                                                                     declinedPermissions:[currentToken.declinedPermissions allObjects]
                                                                                    appID:currentToken.appID
                                                                                   userID:currentToken.userID
                                                                           expirationDate:[NSDate distantFuture]

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKTriStateBOOL.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKTriStateBOOL.m
@@ -26,7 +26,7 @@ FBSDKTriStateBOOL FBSDKTriStateBOOLFromBOOL(BOOL value)
 FBSDKTriStateBOOL FBSDKTriStateBOOLFromNSNumber(NSNumber *value)
 {
   return ([value isKindOfClass:[NSNumber class]] ?
-          FBSDKTriStateBOOLFromBOOL(value.boolValue) :
+          FBSDKTriStateBOOLFromBOOL([value boolValue]) :
           FBSDKTriStateBOOLValueUnknown);
 }
 

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKTypeUtility.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKTypeUtility.m
@@ -31,10 +31,10 @@
 {
   if ([object isKindOfClass:[NSNumber class]]) {
     // @0 or @NO returns NO, otherwise YES
-    return ((NSNumber *)object).boolValue;
+    return [(NSNumber *)object boolValue];
   } else if ([object isKindOfClass:[NSString class]]) {
     // Returns YES on encountering one of "Y", "y", "T", "t", or a digit 1-9, otherwise NO
-    return ((NSString *)object).boolValue;
+    return [(NSString *)object boolValue];
   } else {
     return ([self objectValue:object] != nil);
   }
@@ -48,9 +48,9 @@
 + (NSInteger)integerValue:(id)object
 {
   if ([object isKindOfClass:[NSNumber class]]) {
-    return ((NSNumber *)object).integerValue;
+    return [(NSNumber *)object integerValue];
   } else if ([object isKindOfClass:[NSString class]]) {
-    return ((NSString *)object).integerValue;
+    return [(NSString *)object integerValue];
   } else {
     return 0;
   }
@@ -66,9 +66,9 @@
   if ([object isKindOfClass:[NSString class]]) {
     return (NSString *)object;
   } else if ([object isKindOfClass:[NSNumber class]]) {
-    return ((NSNumber *)object).stringValue;
+    return [(NSNumber *)object stringValue];
   } else if ([object isKindOfClass:[NSURL class]]) {
-    return ((NSURL *)object).absoluteString;
+    return [(NSURL *)object absoluteString];
   } else {
     return nil;
   }
@@ -77,9 +77,9 @@
 + (NSTimeInterval)timeIntervalValue:(id)object
 {
   if ([object isKindOfClass:[NSNumber class]]) {
-    return ((NSNumber *)object).doubleValue;
+    return [(NSNumber *)object doubleValue];
   } else if ([object isKindOfClass:[NSString class]]) {
-    return ((NSString *)object).doubleValue;
+    return [(NSString *)object doubleValue];
   } else {
     return 0;
   }
@@ -88,7 +88,7 @@
 + (NSUInteger)unsignedIntegerValue:(id)object
 {
   if ([object isKindOfClass:[NSNumber class]]) {
-    return ((NSNumber *)object).unsignedIntegerValue;
+    return [(NSNumber *)object unsignedIntegerValue];
   } else {
     // there is no direct support for strings containing unsigned values > NSIntegerMax - not worth writing ourselves
     // right now, so just cap unsigned values at NSIntegerMax until we have a need for larger

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/Network/FBSDKGraphRequest+Internal.h
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/Network/FBSDKGraphRequest+Internal.h
@@ -46,9 +46,8 @@ typedef NS_OPTIONS(NSUInteger, FBSDKGraphRequestFlags)
 // out of context of any user action.
 @property (nonatomic, assign) FBSDKGraphRequestFlags flags;
 
-@property (nonatomic, readonly, getter=isGraphErrorRecoveryDisabled) BOOL graphErrorRecoveryDisabled;
-@property (nonatomic, readonly) BOOL hasAttachments;
-
+- (BOOL)isGraphErrorRecoveryDisabled;
+- (BOOL)hasAttachments;
 + (BOOL)isAttachment:(id)item;
 + (NSString *)serializeURL:(NSString *)baseUrl
                     params:(NSDictionary *)params

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/Network/FBSDKGraphRequestBody.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/Network/FBSDKGraphRequestBody.m
@@ -54,7 +54,7 @@
 
 - (void)appendUTF8:(NSString *)utf8
 {
-  if (!_data.length) {
+  if (![_data length]) {
     NSString *headerUTF8 = [NSString stringWithFormat:@"--%@%@", _stringBoundary, kNewline];
     NSData *headerData = [headerUTF8 dataUsingEncoding:NSUTF8StringEncoding];
     [_data appendData:headerData];
@@ -71,7 +71,7 @@
     [self appendUTF8:value];
   }];
   if (key && value) {
-    _json[key] = value;
+    [_json setObject:value forKey:key];
   }
   [logger appendFormat:@"\n    %@:\t%@", key, (NSString *)value];
 }
@@ -85,7 +85,7 @@
     [self->_data appendData:data];
   }];
   _json = nil;
-  [logger appendFormat:@"\n    %@:\t<Image - %lu kB>", key, (unsigned long)(data.length / 1024)];
+  [logger appendFormat:@"\n    %@:\t<Image - %lu kB>", key, (unsigned long)([data length] / 1024)];
 }
 
 - (void)appendWithKey:(NSString *)key
@@ -96,7 +96,7 @@
     [self->_data appendData:data];
   }];
   _json = nil;
-  [logger appendFormat:@"\n    %@:\t<Data - %lu kB>", key, (unsigned long)(data.length / 1024)];
+  [logger appendFormat:@"\n    %@:\t<Data - %lu kB>", key, (unsigned long)([data length] / 1024)];
 }
 
 - (void)appendWithKey:(NSString *)key
@@ -110,7 +110,7 @@
     [self->_data appendData:data];
   }];
   _json = nil;
-  [logger appendFormat:@"\n    %@:\t<Data - %lu kB>", key, (unsigned long)(data.length / 1024)];
+  [logger appendFormat:@"\n    %@:\t<Data - %lu kB>", key, (unsigned long)([data length] / 1024)];
 }
 
 - (NSData *)data

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/Network/FBSDKGraphRequestPiggybackManager.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/Network/FBSDKGraphRequestPiggybackManager.m
@@ -31,7 +31,7 @@ static int const FBSDKTokenRefreshRetrySeconds = 60 * 60;           // hour
     BOOL safeForPiggyback = YES;
     for (FBSDKGraphRequestMetadata *metadata in connection.requests) {
       if (![metadata.request.version isEqualToString:[FBSDKSettings graphAPIVersion]] ||
-          metadata.request.hasAttachments) {
+          [metadata.request hasAttachments]) {
         safeForPiggyback = NO;
         break;
       }
@@ -57,19 +57,19 @@ static int const FBSDKTokenRefreshRetrySeconds = 60 * 60;           // hour
       FBSDKAccessToken *currentToken = [FBSDKAccessToken currentAccessToken];
       NSDate *expirationDate = currentToken.expirationDate;
       if (expirationDateNumber) {
-        expirationDate = (expirationDateNumber.doubleValue > 0 ?
-                          [NSDate dateWithTimeIntervalSince1970:expirationDateNumber.doubleValue] :
+        expirationDate = ([expirationDateNumber doubleValue] > 0 ?
+                          [NSDate dateWithTimeIntervalSince1970:[expirationDateNumber doubleValue]] :
                           [NSDate distantFuture]);
       }
       NSDate *dataExpirationDate = currentToken.dataAccessExpirationDate;
       if (dataAccessExpirationDateNumber) {
-            dataExpirationDate = (dataAccessExpirationDateNumber.doubleValue > 0 ?
-                              [NSDate dateWithTimeIntervalSince1970:dataAccessExpirationDateNumber.doubleValue] :
+            dataExpirationDate = ([dataAccessExpirationDateNumber doubleValue] > 0 ?
+                              [NSDate dateWithTimeIntervalSince1970:[dataAccessExpirationDateNumber doubleValue]] :
                               [NSDate distantFuture]);
       }
       FBSDKAccessToken *refreshedToken = [[FBSDKAccessToken alloc] initWithTokenString:tokenString ?: currentToken.tokenString
-                                                                           permissions:(permissions ?: currentToken.permissions).allObjects
-                                                                   declinedPermissions:(declinedPermissions ?: currentToken.declinedPermissions).allObjects
+                                                                           permissions:[(permissions ?: currentToken.permissions) allObjects]
+                                                                   declinedPermissions:[(declinedPermissions ?: currentToken.declinedPermissions) allObjects]
                                                                                  appID:currentToken.appID
                                                                                 userID:currentToken.userID
                                                                         expirationDate:expirationDate
@@ -135,7 +135,7 @@ static int const FBSDKTokenRefreshRetrySeconds = 60 * 60;           // hour
 
 + (void)addServerConfigurationPiggyback:(FBSDKGraphRequestConnection *)connection
 {
-  if (![FBSDKServerConfigurationManager cachedServerConfiguration].isDefaults
+  if (![[FBSDKServerConfigurationManager cachedServerConfiguration] isDefaults]
       && [[NSDate date] timeIntervalSinceDate:[FBSDKServerConfigurationManager cachedServerConfiguration].timestamp]
       < FBSDK_SERVER_CONFIGURATION_MANAGER_CACHE_TIMEOUT) {
     return;

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/Network/FBSDKURLSessionTask.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/Network/FBSDKURLSessionTask.m
@@ -62,8 +62,8 @@
     NSString *logEntry = [NSString
                           stringWithFormat:@"FBSDKURLSessionTask <#%lu>:\n  Error: '%@'\n%@\n",
                           (unsigned long)self.loggerSerialNumber,
-                          error.localizedDescription,
-                          error.userInfo];
+                          [error localizedDescription],
+                          [error userInfo]];
 
     [self logMessage:logEntry];
   }
@@ -75,11 +75,11 @@
                    response:(NSURLResponse *)response
                responseData:(NSData *)responseData {
   // Basic FBSDKURLSessionTask logging just prints out the URL.  FBSDKGraphRequest logging provides more details.
-  NSString *mimeType = response.MIMEType;
+  NSString *mimeType = [response MIMEType];
   NSMutableString *mutableLogEntry = [NSMutableString stringWithFormat:@"FBSDKURLSessionTask <#%lu>:\n  Duration: %llu msec\nResponse Size: %lu kB\n  MIME type: %@\n",
                                       (unsigned long)self.loggerSerialNumber,
                                       [FBSDKInternalUtility currentTimeInMilliseconds] - self.requestStartTime,
-                                      (unsigned long)responseData.length / 1024,
+                                      (unsigned long)[responseData length] / 1024,
                                       mimeType];
 
   if ([mimeType isEqualToString:@"text/javascript"]) {

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKErrorConfiguration.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKErrorConfiguration.m
@@ -123,18 +123,18 @@ static NSString *const kErrorCategoryLogin = @"login";
         NSArray *subcodes = codeSubcodesDictionary[@"subcodes"];
         if (subcodes.count > 0) {
           for (NSNumber *subcodeNumber in subcodes) {
-            currentSubcodes[subcodeNumber.stringValue] = [[FBSDKErrorRecoveryConfiguration alloc]
+            currentSubcodes[[subcodeNumber stringValue]] = [[FBSDKErrorRecoveryConfiguration alloc]
+                                                            initWithRecoveryDescription:suggestion
+                                                            optionDescriptions:options
+                                                            category:category
+                                                            recoveryActionName:action];
+          }
+        } else {
+          currentSubcodes[@"*"] = [[FBSDKErrorRecoveryConfiguration alloc]
                                                           initWithRecoveryDescription:suggestion
                                                           optionDescriptions:options
                                                           category:category
                                                           recoveryActionName:action];
-          }
-        } else {
-          currentSubcodes[@"*"] = [[FBSDKErrorRecoveryConfiguration alloc]
-                                   initWithRecoveryDescription:suggestion
-                                   optionDescriptions:options
-                                   category:category
-                                   recoveryActionName:action];
         }
       }
     }];

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKErrorRecoveryConfiguration.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKErrorRecoveryConfiguration.m
@@ -54,7 +54,7 @@
 
   return [self initWithRecoveryDescription:description
                         optionDescriptions:options
-                                  category:category.unsignedIntegerValue
+                                  category:[category unsignedIntegerValue]
                         recoveryActionName:action];
 }
 

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKGateKeeperManager.h
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKGateKeeperManager.h
@@ -18,8 +18,6 @@
 
 #import <Foundation/Foundation.h>
 
-#define FBSDK_GATEKEEPER_MANAGER_CACHE_TIMEOUT (60 * 60)
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface FBSDKGateKeeperManager : NSObject

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKServerConfiguration.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKServerConfiguration.m
@@ -157,12 +157,12 @@ implicitPurchaseLoggingEnabled:(BOOL)implicitPurchaseLoggingEnabled
 - (BOOL)_useFeatureWithKey:(NSString *)key dialogName:(NSString *)dialogName
 {
   if ([dialogName isEqualToString:FBSDKDialogConfigurationNameLogin]) {
-    return ((NSNumber *)(_dialogFlows[dialogName][key] ?:
-                         _dialogFlows[FBSDKDialogConfigurationNameDefault][key])).boolValue;
+    return [(NSNumber *)(_dialogFlows[dialogName][key] ?:
+                         _dialogFlows[FBSDKDialogConfigurationNameDefault][key]) boolValue];
   } else {
-    return ((NSNumber *)(_dialogFlows[dialogName][key] ?:
+    return [(NSNumber *)(_dialogFlows[dialogName][key] ?:
                          _dialogFlows[FBSDKDialogConfigurationNameSharing][key] ?:
-                         _dialogFlows[FBSDKDialogConfigurationNameDefault][key])).boolValue;
+                         _dialogFlows[FBSDKDialogConfigurationNameDefault][key]) boolValue];
   }
 }
 

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKServerConfigurationManager.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKServerConfigurationManager.m
@@ -21,7 +21,6 @@
 #import <objc/runtime.h>
 
 #import "FBSDKAppEventsUtility.h"
-#import "FBSDKGateKeeperManager.h"
 #import "FBSDKGraphRequest+Internal.h"
 #import "FBSDKGraphRequest.h"
 #import "FBSDKImageDownloader.h"
@@ -169,9 +168,6 @@ typedef NS_OPTIONS(NSUInteger, FBSDKServerConfigurationManagerAppEventsFeatures)
   if (loadBlock != NULL) {
     loadBlock();
   }
-
-  // Fetch app gatekeepers
-  [FBSDKGateKeeperManager loadGateKeepers];
 }
 
 #pragma mark - Internal Class Methods
@@ -289,10 +285,13 @@ typedef NS_OPTIONS(NSUInteger, FBSDKServerConfigurationManagerAppEventsFeatures)
                       FBSDK_SERVER_CONFIGURATION_SMART_LOGIN_MENU_ICON_URL_FIELD
 #endif
                       ];
-  NSString *advertiserID = [FBSDKAppEventsUtility advertiserID] ?: @"";
-  NSDictionary<NSString *, NSString *> *parameters = @{ @"fields": [fields componentsJoinedByString:@","],
-                                @"advertiser_id": advertiserID
-                                };
+  NSDictionary *parameters = @{ @"fields": [fields componentsJoinedByString:@","] };
+  NSString *advertiserID = [FBSDKAppEventsUtility advertiserID];
+
+  if (advertiserID) {
+    parameters = @{ @"fields": [fields componentsJoinedByString:@","],
+                    @"advertiser_id": advertiserID };
+  }
 
   FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:appID
                                                                  parameters:parameters
@@ -382,7 +381,7 @@ typedef NS_OPTIONS(NSUInteger, FBSDKServerConfigurationManagerAppEventsFeatures)
 
 #ifdef DEBUG
       NSString *updateMessage = _serverConfiguration.updateMessage;
-      if (updateMessage && updateMessage.length > 0 && !_printedUpdateMessage) {
+      if (updateMessage && [updateMessage length] > 0 && !_printedUpdateMessage) {
         _printedUpdateMessage = YES;
         NSLog(@"%@", updateMessage);
       }
@@ -419,7 +418,7 @@ typedef NS_OPTIONS(NSUInteger, FBSDKServerConfigurationManagerAppEventsFeatures)
     NSDictionary *dialogConfigurationDictionary = [FBSDKTypeUtility dictionaryValue:dialogConfiguration];
     if (dialogConfigurationDictionary) {
       NSString *name = [FBSDKTypeUtility stringValue:dialogConfigurationDictionary[@"name"]];
-      if (name.length) {
+      if ([name length]) {
         NSURL *URL = [FBSDKTypeUtility URLValue:dialogConfigurationDictionary[@"url"]];
         NSArray *appVersions = [FBSDKTypeUtility arrayValue:dialogConfigurationDictionary[@"versions"]];
         dialogConfigurations[name] = [[FBSDKDialogConfiguration alloc] initWithName:name

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKAccessTokenCache.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKAccessTokenCache.m
@@ -27,9 +27,9 @@ static BOOL g_tryDeprecatedCaches = YES;
 
 @implementation FBSDKAccessTokenCache
 
-- (FBSDKAccessToken*)accessToken
+- (FBSDKAccessToken*)fetchAccessToken
 {
-  FBSDKAccessToken *token = [[FBSDKAccessTokenCacheV4 alloc] init].accessToken;
+  FBSDKAccessToken *token = [[[FBSDKAccessTokenCacheV4 alloc] init] fetchAccessToken];
   if (token || !g_tryDeprecatedCaches) {
     return token;
   }
@@ -39,21 +39,21 @@ static BOOL g_tryDeprecatedCaches = YES;
   __block FBSDKAccessToken *oldToken = nil;
   [oldCacheClasses enumerateObjectsUsingBlock:^(Class obj, NSUInteger idx, BOOL *stop) {
     id<FBSDKAccessTokenCaching> cache = [[obj alloc] init];
-    oldToken = cache.accessToken;
+    oldToken = [cache fetchAccessToken];
     if (oldToken) {
       *stop = YES;
       [cache clearCache];
     }
   }];
   if (oldToken) {
-    self.accessToken = oldToken;
+    [self cacheAccessToken:oldToken];
   }
   return oldToken;
 }
 
-- (void)setAccessToken:(FBSDKAccessToken *)token
+- (void)cacheAccessToken:(FBSDKAccessToken *)token
 {
-  [[FBSDKAccessTokenCacheV4 alloc] init].accessToken = token;
+  [[[FBSDKAccessTokenCacheV4 alloc] init] cacheAccessToken:token];
   if (g_tryDeprecatedCaches) {
     g_tryDeprecatedCaches = NO;
     NSArray *oldCacheClasses = [[self class] deprecatedCacheClasses];

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKAccessTokenCacheV3.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKAccessTokenCacheV3.m
@@ -35,7 +35,7 @@ NSString *const FBSDKTokenInformationUUIDKey = @"com.facebook.sdk:TokenInformati
 
 @implementation FBSDKAccessTokenCacheV3
 
-- (FBSDKAccessToken *)accessToken
+- (FBSDKAccessToken *)fetchAccessToken
 {
   // Check NSUserDefaults ( <= v3.16 )
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
@@ -50,7 +50,7 @@ NSString *const FBSDKTokenInformationUUIDKey = @"com.facebook.sdk:TokenInformati
   [defaults synchronize];
 }
 
-- (void)setAccessToken:(FBSDKAccessToken *)token
+- (void)cacheAccessToken:(FBSDKAccessToken *)token
 {
   //no-op.
   NSAssert(NO, @"deprecated cache FBSDKAccessTokenCacheV3 should not be used to cache a token");

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKAccessTokenCacheV3_17.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKAccessTokenCacheV3_17.m
@@ -36,7 +36,7 @@
   }
   return self;
 }
-- (FBSDKAccessToken *)accessToken
+- (FBSDKAccessToken *)fetchAccessToken
 {
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   NSString *uuidKey = [[FBSDKSettings legacyUserDefaultTokenInformationKeyName] stringByAppendingString:@"UUID"];
@@ -54,7 +54,7 @@
   [_keychainStore setDictionary:nil forKey:[FBSDKSettings legacyUserDefaultTokenInformationKeyName] accessibility:nil];
 }
 
-- (void)setAccessToken:(FBSDKAccessToken *)token
+- (void)cacheAccessToken:(FBSDKAccessToken *)token
 {
   //no-op.
   NSAssert(NO, @"deprecated cache FBSDKAccessTokenCacheV3_17 should not be used to cache a token");

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKAccessTokenCacheV3_21.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKAccessTokenCacheV3_21.m
@@ -32,13 +32,13 @@
 - (instancetype)init
 {
   if ((self = [super init])) {
-    NSString *keyChainServiceIdentifier = [NSString stringWithFormat:@"com.facebook.sdk.tokencache.%@", [NSBundle mainBundle].bundleIdentifier];
+    NSString *keyChainServiceIdentifier = [NSString stringWithFormat:@"com.facebook.sdk.tokencache.%@", [[NSBundle mainBundle] bundleIdentifier]];
     _keychainStore = [[FBSDKKeychainStore alloc] initWithService:keyChainServiceIdentifier accessGroup:nil];
   }
   return self;
 }
 
-- (FBSDKAccessToken *)accessToken
+- (FBSDKAccessToken *)fetchAccessToken
 {
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   NSString *uuidKey = [[FBSDKSettings legacyUserDefaultTokenInformationKeyName] stringByAppendingString:@"UUID"];
@@ -56,7 +56,7 @@
   [_keychainStore setDictionary:nil forKey:[FBSDKSettings legacyUserDefaultTokenInformationKeyName] accessibility:nil];
 }
 
-- (void)setAccessToken:(FBSDKAccessToken *)token
+- (void)cacheAccessToken:(FBSDKAccessToken *)token
 {
   //no-op.
   NSAssert(NO, @"deprecated cache FBSDKAccessTokenCacheV3_21 should not be used to cache a token");

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKAccessTokenCacheV4.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKAccessTokenCacheV4.m
@@ -35,13 +35,13 @@ static NSString *const kFBSDKAccessTokenEncodedKey = @"tokenEncoded";
 - (instancetype)init
 {
   if ((self = [super init])) {
-    NSString *keyChainServiceIdentifier = [NSString stringWithFormat:@"com.facebook.sdk.tokencache.%@", [NSBundle mainBundle].bundleIdentifier];
+    NSString *keyChainServiceIdentifier = [NSString stringWithFormat:@"com.facebook.sdk.tokencache.%@", [[NSBundle mainBundle] bundleIdentifier]];
     _keychainStore = [[FBSDKKeychainStore alloc] initWithService:keyChainServiceIdentifier accessGroup:nil];
   }
   return self;
 }
 
-- (FBSDKAccessToken *)accessToken
+- (FBSDKAccessToken *)fetchAccessToken
 {
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   NSString *uuid = [defaults objectForKey:kFBSDKAccessTokenUserDefaultsKey];
@@ -63,7 +63,7 @@ static NSString *const kFBSDKAccessTokenEncodedKey = @"tokenEncoded";
   return nil;
 }
 
-- (void)setAccessToken:(FBSDKAccessToken *)token
+- (void)cacheAccessToken:(FBSDKAccessToken *)token
 {
   if (!token) {
     [self clearCache];
@@ -72,7 +72,7 @@ static NSString *const kFBSDKAccessTokenEncodedKey = @"tokenEncoded";
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   NSString *uuid = [defaults objectForKey:kFBSDKAccessTokenUserDefaultsKey];
   if (!uuid) {
-    uuid = [NSUUID UUID].UUIDString;
+    uuid = [[NSUUID UUID] UUIDString];
     [defaults setObject:uuid forKey:kFBSDKAccessTokenUserDefaultsKey];
     [defaults synchronize];
   }

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKAccessTokenCaching.h
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKAccessTokenCaching.h
@@ -22,7 +22,9 @@
 
 @protocol FBSDKAccessTokenCaching<NSObject>
 
-@property (nonatomic, copy) FBSDKAccessToken *accessToken;
+- (FBSDKAccessToken *)fetchAccessToken;
+
+- (void)cacheAccessToken:(FBSDKAccessToken *)token;
 
 - (void)clearCache;
 

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKAccessTokenExpirer.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKAccessTokenExpirer.m
@@ -52,7 +52,7 @@
   if (accessToken == nil || accessToken.isExpired) {
     return;
   }
-  _timer = [NSTimer scheduledTimerWithTimeInterval:accessToken.expirationDate.timeIntervalSinceNow target:self selector:@selector(_timerDidFire) userInfo:nil repeats:NO];
+  _timer = [NSTimer scheduledTimerWithTimeInterval:[accessToken.expirationDate timeIntervalSinceNow] target:self selector:@selector(_timerDidFire) userInfo:nil repeats:NO];
 }
 
 - (void)_timerDidFire
@@ -61,7 +61,7 @@
   NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
   [FBSDKInternalUtility dictionary:userInfo setObject:accessToken forKey:FBSDKAccessTokenChangeNewKey];
   [FBSDKInternalUtility dictionary:userInfo setObject:accessToken forKey:FBSDKAccessTokenChangeOldKey];
-  userInfo[FBSDKAccessTokenDidExpireKey] = @YES;
+  userInfo[FBSDKAccessTokenDidExpire] = @YES;
 
   [[NSNotificationCenter defaultCenter] postNotificationName:FBSDKAccessTokenDidChangeNotification
                                                       object:[FBSDKAccessToken class]

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKKeychainStore.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKKeychainStore.m
@@ -31,7 +31,7 @@
 - (instancetype)initWithService:(NSString *)service accessGroup:(NSString *)accessGroup
 {
     if ((self = [super init])) {
-      _service = service ? [service copy] : [NSBundle mainBundle].bundleIdentifier;
+      _service = service ? [service copy] : [[NSBundle mainBundle] bundleIdentifier];
         _accessGroup = [accessGroup copy];
         NSAssert(_service, @"Keychain must be initialized with service");
     }

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKKeychainStoreViaBundleID.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKKeychainStoreViaBundleID.m
@@ -25,7 +25,7 @@
 
 - (instancetype)init
 {
-  return [super initWithService:[NSBundle mainBundle].bundleIdentifier accessGroup:nil];
+  return [super initWithService:[[NSBundle mainBundle] bundleIdentifier] accessGroup:nil];
 }
 
 - (instancetype)initWithService:(NSString *)service accessGroup:(NSString *)accessGroup

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKButton+Subclass.h
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKButton+Subclass.h
@@ -24,15 +24,13 @@
 
 @protocol FBSDKButtonImpressionTracking <NSObject>
 
-@property (nonatomic, readonly, copy) NSDictionary<NSString *, id> *analyticsParameters;
-@property (nonatomic, readonly, copy) NSString *impressionTrackingEventName;
-@property (nonatomic, readonly, copy) NSString *impressionTrackingIdentifier;
+- (NSDictionary *)analyticsParameters;
+- (NSString *)impressionTrackingEventName;
+- (NSString *)impressionTrackingIdentifier;
 
 @end
 
 @interface FBSDKButton ()
-
-@property (nonatomic, readonly, getter=isImplicitlyDisabled) BOOL implicitlyDisabled;
 
 - (void)logTapEventWithEventName:(NSString *)eventName
                       parameters:(NSDictionary *)parameters;
@@ -56,6 +54,7 @@
 - (UIColor *)defaultHighlightedColor;
 - (FBSDKIcon *)defaultIcon;
 - (UIColor *)defaultSelectedColor;
+- (BOOL)isImplicitlyDisabled;
 - (CGSize)sizeThatFits:(CGSize)size title:(NSString *)title;
 
 @end

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal_NoARC/FBSDKDynamicFrameworkLoader.m
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit/Internal_NoARC/FBSDKDynamicFrameworkLoader.m
@@ -55,7 +55,7 @@ static void *fbsdkdfl_load_library_once(const char *path)
 static void *fbsdkdfl_load_framework_once(NSString *framework)
 {
   NSString *path = [NSString stringWithFormat:g_frameworkPathTemplate, framework, framework];
-  return fbsdkdfl_load_library_once(path.fileSystemRepresentation);
+  return fbsdkdfl_load_library_once([path fileSystemRepresentation]);
 }
 
 // Implements the callback for dispatch_once() that loads the handle for specified framework name

--- a/ios/Anywhere Reader/Pods/FBSDKCoreKit/README.md
+++ b/ios/Anywhere Reader/Pods/FBSDKCoreKit/README.md
@@ -1,7 +1,5 @@
 # Facebook SDK for iOS
 
-[![Build Status](https://travis-ci.org/facebook/facebook-objc-sdk.svg?branch=master)](https://travis-ci.org/facebook/facebook-objc-sdk)
-
 This open-source library allows you to integrate Facebook into your iOS app.
 
 Learn more about the provided samples, documentation, integrating the SDK into your app, accessing source code, and more at https://developers.facebook.com/docs/ios

--- a/ios/Anywhere Reader/Pods/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.m
+++ b/ios/Anywhere Reader/Pods/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.m
@@ -127,7 +127,7 @@ static const CGFloat kPaddingBetweenLogoTitle = 8.0;
 
 - (CGSize)sizeThatFits:(CGSize)size
 {
-  if (self.hidden) {
+  if ([self isHidden]) {
     return CGSizeZero;
   }
   UIFont *font = self.titleLabel.font;
@@ -171,11 +171,11 @@ static const CGFloat kPaddingBetweenLogoTitle = 8.0;
 
   [self configureWithIcon:nil
                     title:logInTitle
-          backgroundColor:self.backgroundColor
+          backgroundColor:[self backgroundColor]
          highlightedColor:nil
             selectedTitle:logOutTitle
              selectedIcon:nil
-            selectedColor:self.backgroundColor
+            selectedColor:[self backgroundColor]
  selectedHighlightedColor:nil];
   self.titleLabel.textAlignment = NSTextAlignmentCenter;
   [self addConstraint:[NSLayoutConstraint constraintWithItem:self
@@ -198,14 +198,14 @@ static const CGFloat kPaddingBetweenLogoTitle = 8.0;
 
 - (void)_accessTokenDidChangeNotification:(NSNotification *)notification
 {
-  if (notification.userInfo[FBSDKAccessTokenDidChangeUserIDKey] || notification.userInfo[FBSDKAccessTokenDidExpireKey]) {
+  if (notification.userInfo[FBSDKAccessTokenDidChangeUserID] || notification.userInfo[FBSDKAccessTokenDidExpire]) {
     [self _updateContent];
   }
 }
 
 - (void)_buttonPressed:(id)sender
 {
-  [self logTapEventWithEventName:FBSDKAppEventNameFBSDKLoginButtonDidTap parameters:self.analyticsParameters];
+  [self logTapEventWithEventName:FBSDKAppEventNameFBSDKLoginButtonDidTap parameters:[self analyticsParameters]];
   if ([FBSDKAccessToken currentAccessTokenIsActive]) {
     NSString *title = nil;
 
@@ -280,6 +280,7 @@ static const CGFloat kPaddingBetweenLogoTitle = 8.0;
   return NSLocalizedStringWithDefaultValue(@"LoginButton.LogOut", @"FacebookSDK", [FBSDKInternalUtility bundleForStrings],
                                            @"Log out",
                                            @"The label for the FBSDKLoginButton when the user is currently logged in");
+  ;
 }
 
 - (NSString *)_longLogInTitle

--- a/ios/Anywhere Reader/Pods/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.m
+++ b/ios/Anywhere Reader/Pods/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.m
@@ -65,7 +65,7 @@ typedef NS_ENUM(NSInteger, FBSDKLoginManagerState) {
   self = [super init];
   if (self) {
     self.authType = @"rerequest";
-    NSString *keyChainServiceIdentifier = [NSString stringWithFormat:@"com.facebook.sdk.loginmanager.%@", [NSBundle mainBundle].bundleIdentifier];
+    NSString *keyChainServiceIdentifier = [NSString stringWithFormat:@"com.facebook.sdk.loginmanager.%@", [[NSBundle mainBundle] bundleIdentifier]];
     _keychainStore = [[FBSDKKeychainStore alloc] initWithService:keyChainServiceIdentifier accessGroup:nil];
   }
   return self;
@@ -255,8 +255,8 @@ typedef NS_ENUM(NSInteger, FBSDKLoginManagerState) {
 
       if (recentlyGrantedPermissions.count > 0) {
         FBSDKAccessToken *token = [[FBSDKAccessToken alloc] initWithTokenString:tokenString
-                                                                    permissions:grantedPermissions.allObjects
-                                                            declinedPermissions:declinedPermissions.allObjects
+                                                                    permissions:[grantedPermissions allObjects]
+                                                            declinedPermissions:[declinedPermissions allObjects]
                                                                           appID:parameters.appID
                                                                          userID:parameters.userID
                                                                  expirationDate:parameters.expirationDate
@@ -377,7 +377,7 @@ typedef NS_ENUM(NSInteger, FBSDKLoginManagerState) {
 
   [FBSDKInternalUtility dictionary:loginParams setObject:[FBSDKSettings appURLSchemeSuffix] forKey:@"local_client_id"];
   [FBSDKInternalUtility dictionary:loginParams setObject:[FBSDKLoginUtility stringForAudience:self.defaultAudience] forKey:@"default_audience"];
-  [FBSDKInternalUtility dictionary:loginParams setObject:[permissions.allObjects componentsJoinedByString:@","] forKey:@"scope"];
+  [FBSDKInternalUtility dictionary:loginParams setObject:[[permissions allObjects] componentsJoinedByString:@","] forKey:@"scope"];
 
   NSString *expectedChallenge = [FBSDKLoginManager stringForChallenge];
   NSDictionary *state = @{@"challenge": [FBSDKUtility URLEncode:expectedChallenge]};
@@ -546,7 +546,7 @@ typedef NS_ENUM(NSInteger, FBSDKLoginManagerState) {
 
   NSDate *start = [NSDate date];
   [[FBSDKApplicationDelegate sharedInstance] openURL:authURL sender:self handler:^(BOOL openedURL, NSError *anError) {
-    [self->_logger logNativeAppDialogResult:openedURL dialogDuration:-start.timeIntervalSinceNow];
+    [self->_logger logNativeAppDialogResult:openedURL dialogDuration:-[start timeIntervalSinceNow]];
     if (handler) {
       handler(openedURL, anError);
     }
@@ -634,8 +634,8 @@ typedef NS_ENUM(NSInteger, FBSDKLoginManagerState) {
         annotation:(id)annotation
 {
   // verify the URL is intended as a callback for the SDK's log in
-  BOOL isFacebookURL = [url.scheme hasPrefix:[NSString stringWithFormat:@"fb%@", [FBSDKSettings appID]]] &&
-  [url.host isEqualToString:@"authorize"];
+  BOOL isFacebookURL = [[url scheme] hasPrefix:[NSString stringWithFormat:@"fb%@", [FBSDKSettings appID]]] &&
+  [[url host] isEqualToString:@"authorize"];
 
   BOOL isExpectedSourceApplication = [sourceApplication hasPrefix:@"com.facebook"] || [sourceApplication hasPrefix:@"com.apple"] || [sourceApplication hasPrefix:@"com.burbn"];
 

--- a/ios/Anywhere Reader/Pods/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginKit/FBSDKTooltipView.m
+++ b/ios/Anywhere Reader/Pods/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginKit/FBSDKTooltipView.m
@@ -82,7 +82,7 @@ static CGMutablePathRef _fbsdkCreateDownPointingBubbleWithRect(CGRect rect, CGFl
     _verticalCrossOffset = - 2.5f;
     _verticalTextOffset = 0;
     _displayDuration = 6.0;
-    self.colorStyle = colorStyle;
+    [self setColorStyle:colorStyle];
 
     _message = [message copy];
     _tagline = [tagline copy];
@@ -160,7 +160,7 @@ static CGMutablePathRef _fbsdkCreateDownPointingBubbleWithRect(CGRect rect, CGFl
 
   // Add to view, while invisible.
   self.hidden = YES;
-  if (self.superview) {
+  if ([self superview]) {
     [self removeFromSuperview];
   }
   [view addSubview:self];
@@ -473,7 +473,7 @@ static CGMutablePathRef _createCloseCrossGlyphWithRect(CGRect rect)
 - (CGRect)layoutSubviewsAndDetermineFrame
 {
   // Compute the positioning of the arrow.
-  CGRect screenBounds = [UIScreen mainScreen].bounds;
+  CGRect screenBounds = [[UIScreen mainScreen] bounds];
   UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
   if (!UIInterfaceOrientationIsPortrait(orientation)) {
     screenBounds = CGRectMake(0, 0, screenBounds.size.height, screenBounds.size.width);
@@ -542,7 +542,7 @@ static CGMutablePathRef _createCloseCrossGlyphWithRect(CGRect rect)
   message = message ?: @"";
   // Ensure tagline is empty string or ends with space
   tagline = tagline ?: @"";
-  if (tagline.length && ![tagline hasSuffix:@" "])
+  if ([tagline length] && ![tagline hasSuffix:@" "])
     tagline = [tagline stringByAppendingString:@" "];
 
   // Concatenate tagline & main message
@@ -554,8 +554,8 @@ static CGMutablePathRef _createCloseCrossGlyphWithRect(CGRect rect)
   UIFont *font=[UIFont boldSystemFontOfSize:kNUXFontSize];
   [attrString addAttribute:NSFontAttributeName value:font range:fullRange];
   [attrString addAttribute:NSForegroundColorAttributeName value:[UIColor whiteColor] range:fullRange];
-  if (tagline.length) {
-    [attrString addAttribute:NSForegroundColorAttributeName value: FBSDKUIColorWithRGB(0x6D, 0x87, 0xC7) range:NSMakeRange(0, tagline.length)];
+  if ([tagline length]) {
+    [attrString addAttribute:NSForegroundColorAttributeName value: FBSDKUIColorWithRGB(0x6D, 0x87, 0xC7) range:NSMakeRange(0, [tagline length])];
   }
 
   _textLabel.attributedText = attrString;
@@ -572,7 +572,7 @@ static CGMutablePathRef _createCloseCrossGlyphWithRect(CGRect rect)
 {
   [[self class] cancelPreviousPerformRequestsWithTarget:self selector:@selector(scheduleFadeoutRespectingMinimumDisplayDuration) object:nil];
 
-  if (_displayDuration > 0.0 && self.superview) {
+  if (_displayDuration > 0.0 && [self superview]) {
     CFTimeInterval intervalAlreadyDisplaying = CFAbsoluteTimeGetCurrent() - _displayTime;
     CFTimeInterval timeRemainingBeforeAutomaticFadeout = _displayDuration - intervalAlreadyDisplaying;
     if (timeRemainingBeforeAutomaticFadeout > 0.0) {

--- a/ios/Anywhere Reader/Pods/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginCompletion.m
+++ b/ios/Anywhere Reader/Pods/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginCompletion.m
@@ -46,7 +46,7 @@ static void FBSDKLoginRequestMeAndPermissions(FBSDKLoginCompletionParameters *pa
   [connection addRequest:userIDRequest completionHandler:^(FBSDKGraphRequestConnection *requestConnection,
                                                            id result,
                                                            NSError *error) {
-    parameters.userID = result[@"id"];
+    parameters.userID = [result objectForKey:@"id"];
     if (error) {
       parameters.error = error;
     }
@@ -104,8 +104,8 @@ static void FBSDKLoginRequestMeAndPermissions(FBSDKLoginCompletionParameters *pa
 @implementation FBSDKLoginURLCompleter
 {
   FBSDKLoginCompletionParameters *_parameters;
-  id<NSObject> _observer;
-  BOOL _performExplicitFallback;
+  id<NSObject> _observer
+  ;  BOOL _performExplicitFallback;
 }
 
 - (instancetype)initWithURLParameters:(NSDictionary *)parameters appID:(NSString *)appID
@@ -182,8 +182,8 @@ static void FBSDKLoginRequestMeAndPermissions(FBSDKLoginCompletionParameters *pa
 
   NSString *expirationDateString = parameters[@"expires"] ?: parameters[@"expires_at"];
   NSDate *expirationDate = [NSDate distantFuture];
-  if (expirationDateString && expirationDateString.doubleValue > 0) {
-    expirationDate = [NSDate dateWithTimeIntervalSince1970:expirationDateString.doubleValue];
+  if (expirationDateString && [expirationDateString doubleValue] > 0) {
+    expirationDate = [NSDate dateWithTimeIntervalSince1970:[expirationDateString doubleValue]];
   } else if (parameters[@"expires_in"] && [parameters[@"expires_in"] integerValue] > 0) {
     expirationDate = [NSDate dateWithTimeIntervalSinceNow:[parameters[@"expires_in"] integerValue]];
   }

--- a/ios/Anywhere Reader/Pods/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginManagerLogger.m
+++ b/ios/Anywhere Reader/Pods/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginManagerLogger.m
@@ -86,7 +86,7 @@ static NSString *const FBSDKLoginManagerLoggerTryWebView = @"tryFallback";
 - (instancetype)initWithLoggingToken:(NSString *)loggingToken
 {
   if ((self = [super init]) != nil) {
-    _identifier = [NSUUID UUID].UUIDString;
+    _identifier = [[NSUUID UUID] UUIDString];
     _extras = [NSMutableDictionary dictionary];
     _loggingToken = [loggingToken copy];
   }
@@ -132,7 +132,7 @@ static NSString *const FBSDKLoginManagerLoggerTryWebView = @"tryFallback";
     @"isReauthorize" : @(isReauthorize),
     @"login_behavior" : behaviorString,
     @"default_audience" : [FBSDKLoginUtility stringForAudience:loginManager.defaultAudience],
-    @"permissions" : [loginManager.requestedPermissions.allObjects componentsJoinedByString:@","] ?: @""
+    @"permissions" : [[loginManager.requestedPermissions allObjects] componentsJoinedByString:@","] ?: @""
   }];
 
   [self logEvent:FBSDKAppEventNameFBSessionAuthStart params:[self _parametersForNewEvent]];
@@ -162,7 +162,7 @@ static NSString *const FBSDKLoginManagerLoggerTryWebView = @"tryFallback";
   } else if (result.token) {
     resultString = FBSDKLoginManagerLoggerResultSuccessString;
     if (result.declinedPermissions.count) {
-      _extras[@"declined_permissions"] = [result.declinedPermissions.allObjects componentsJoinedByString:@","];
+      _extras[@"declined_permissions"] = [[result.declinedPermissions allObjects] componentsJoinedByString:@","];
     }
   }
 
@@ -247,7 +247,7 @@ static NSString *const FBSDKLoginManagerLoggerTryWebView = @"tryFallback";
 
     // NOTE: We ALWAYS add all params to each event, to ensure predictable mapping on the backend.
     eventParameters[FBSDKLoginManagerLoggerParamIdentifierKey] = _identifier ?: FBSDKLoginManagerLoggerValueEmpty;
-    eventParameters[FBSDKLoginManagerLoggerParamTimestampKey] = @(round(1000 * [NSDate date].timeIntervalSince1970));
+    eventParameters[FBSDKLoginManagerLoggerParamTimestampKey] = [NSNumber numberWithDouble:round(1000 * [[NSDate date] timeIntervalSince1970])];
     eventParameters[FBSDKLoginManagerLoggerParamResultKey] = FBSDKLoginManagerLoggerValueEmpty;
     [FBSDKInternalUtility dictionary:eventParameters setObject:_authMethod forKey:FBSDKLoginManagerLoggerParamAuthMethodKey];
     eventParameters[FBSDKLoginManagerLoggerParamErrorCodeKey] = FBSDKLoginManagerLoggerValueEmpty;

--- a/ios/Anywhere Reader/Pods/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginUtility.m
+++ b/ios/Anywhere Reader/Pods/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginUtility.m
@@ -41,7 +41,7 @@
 + (NSDictionary *)queryParamsFromLoginURL:(NSURL *)url
 {
   NSString *expectedUrlPrefix = [FBSDKInternalUtility appURLWithHost:@"authorize" path:nil queryParameters:nil error:NULL].absoluteString;
-  if (![url.absoluteString hasPrefix:expectedUrlPrefix]) {
+  if (![[url absoluteString] hasPrefix:expectedUrlPrefix]) {
     // Don't have an App ID, just verify path.
     NSString *host = url.host;
     if (![host isEqualToString:@"authorize"]) {

--- a/ios/Anywhere Reader/Pods/FBSDKLoginKit/README.md
+++ b/ios/Anywhere Reader/Pods/FBSDKLoginKit/README.md
@@ -1,7 +1,5 @@
 # Facebook SDK for iOS
 
-[![Build Status](https://travis-ci.org/facebook/facebook-objc-sdk.svg?branch=master)](https://travis-ci.org/facebook/facebook-objc-sdk)
-
 This open-source library allows you to integrate Facebook into your iOS app.
 
 Learn more about the provided samples, documentation, integrating the SDK into your app, accessing source code, and more at https://developers.facebook.com/docs/ios

--- a/ios/Anywhere Reader/Pods/Manifest.lock
+++ b/ios/Anywhere Reader/Pods/Manifest.lock
@@ -13,15 +13,16 @@ PODS:
     - FacebookCore (~> 0.5)
     - FBSDKCoreKit (~> 4.37)
     - FBSDKLoginKit (~> 4.37)
-  - FBSDKCoreKit (4.39.0):
+  - FBSDKCoreKit (4.38.1):
     - Bolts (~> 1.9)
-  - FBSDKLoginKit (4.39.0):
+  - FBSDKLoginKit (4.38.1):
     - FBSDKCoreKit
   - Kingfisher (5.0.0)
 
 DEPENDENCIES:
-  - FacebookCore
   - FacebookLogin
+  - FBSDKCoreKit (= 4.38.1)
+  - FBSDKLoginKit (= 4.38.1)
   - Kingfisher (~> 5.0)
 
 SPEC REPOS:
@@ -37,10 +38,10 @@ SPEC CHECKSUMS:
   Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
   FacebookCore: 74288d0add931d361b1596beae787ab72c438249
   FacebookLogin: ebcf34714a1cb9f0759d9f071cfb01ed500996cf
-  FBSDKCoreKit: 1e3981faefab8c88edfaa9eecd94aab02d99a9bc
-  FBSDKLoginKit: 30ba5039a2c53d65a75103889bc2deebdacd5a1f
+  FBSDKCoreKit: 8d47857400e2f5bdea697a80daff882e91c84ef6
+  FBSDKLoginKit: 4621c690d9dd8628031a4791497062183ea34b0d
   Kingfisher: 2b0dd651e4fe5a07305b8242fde56f8e2d410f58
 
-PODFILE CHECKSUM: 47ca0feaa04b8ac70125dd14b4c4cdd372655650
+PODFILE CHECKSUM: 9f65762b5bf7f93335f0986cde03d3be8fbd2c1f
 
 COCOAPODS: 1.5.3

--- a/ios/Anywhere Reader/Pods/Target Support Files/FBSDKCoreKit/Info.plist
+++ b/ios/Anywhere Reader/Pods/Target Support Files/FBSDKCoreKit/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>4.39.0</string>
+  <string>4.38.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/ios/Anywhere Reader/Pods/Target Support Files/FBSDKLoginKit/Info.plist
+++ b/ios/Anywhere Reader/Pods/Target Support Files/FBSDKLoginKit/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>4.39.0</string>
+  <string>4.38.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>


### PR DESCRIPTION
# Description

Switches back to old FacebookLogin framework due to a recent update to the Facebook SDK that broke authentication

Fixes: Facebook SDK bug

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Change status

- [X] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [X] Ran on iPhone XR simulator

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts